### PR TITLE
Fixed "PHP Deprecated:  iconv_set_encoding()"

### DIFF
--- a/src/FBAInboundServiceMWS/Client.php
+++ b/src/FBAInboundServiceMWS/Client.php
@@ -576,9 +576,11 @@ class FBAInboundServiceMWS_Client implements FBAInboundServiceMWS_Interface
         $applicationVersion,
         $config = null
     ) {
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if(version_compare(PHP_VERSION, '5.6.0', '<')) {
+            iconv_set_encoding('output_encoding', 'UTF-8');
+            iconv_set_encoding('input_encoding', 'UTF-8');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        }
 
         $this->_awsAccessKeyId = $awsAccessKeyId;
         $this->_awsSecretAccessKey = $awsSecretAccessKey;

--- a/src/FBAInventoryServiceMWS/Client.php
+++ b/src/FBAInventoryServiceMWS/Client.php
@@ -189,9 +189,11 @@ class FBAInventoryServiceMWS_Client implements FBAInventoryServiceMWS_Interface
         $applicationVersion,
         $attributes = null
     ) {
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if(version_compare(PHP_VERSION, '5.6.0', '<')) {
+            iconv_set_encoding('output_encoding', 'UTF-8');
+            iconv_set_encoding('input_encoding', 'UTF-8');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        }
 
         $this->_awsAccessKeyId = $awsAccessKeyId;
         $this->_awsSecretAccessKey = $awsSecretAccessKey;

--- a/src/FBAOutboundServiceMWS/Client.php
+++ b/src/FBAOutboundServiceMWS/Client.php
@@ -428,9 +428,11 @@ class FBAOutboundServiceMWS_Client implements FBAOutboundServiceMWS_Interface
         $applicationVersion,
         $attributes = null
     ) {
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if(version_compare(PHP_VERSION, '5.6.0', '<')) {
+            iconv_set_encoding('output_encoding', 'UTF-8');
+            iconv_set_encoding('input_encoding', 'UTF-8');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        }
 
         $this->_awsAccessKeyId = $awsAccessKeyId;
         $this->_awsSecretAccessKey = $awsSecretAccessKey;

--- a/src/MarketplaceWebService/Client.php
+++ b/src/MarketplaceWebService/Client.php
@@ -83,9 +83,11 @@ class MarketplaceWebService_Client implements MarketplaceWebService_Interface
         $applicationVersion,
         $attributes = null
     ) {
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if(version_compare(PHP_VERSION, '5.6.0', '<')) {
+            iconv_set_encoding('output_encoding', 'UTF-8');
+            iconv_set_encoding('input_encoding', 'UTF-8');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        }
 
         $this->awsAccessKeyId = $awsAccessKeyId;
         $this->awsSecretAccessKey = $awsSecretAccessKey;

--- a/src/MarketplaceWebService/Client.php
+++ b/src/MarketplaceWebService/Client.php
@@ -1057,7 +1057,7 @@ class MarketplaceWebService_Client implements MarketplaceWebService_Interface
             $curlOptions[CURLOPT_PROXY] = $proxy;
         }
         
-        if (!is_null($this->config['CURLOPT_VERBOSE'])) {
+        if (array_key_exists('CURLOPT_VERBOSE', $this->config) && !is_null($this->config['CURLOPT_VERBOSE'])) {
         	$curlOptions[CURLOPT_VERBOSE] = $this->config['CURLOPT_VERBOSE'];
         }
 

--- a/src/MarketplaceWebServiceOrders/Client.php
+++ b/src/MarketplaceWebServiceOrders/Client.php
@@ -228,9 +228,11 @@ class MarketplaceWebServiceOrders_Client implements MarketplaceWebServiceOrders_
         $applicationVersion,
         $config = null
     ) {
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if(version_compare(PHP_VERSION, '5.6.0', '<')) {
+            iconv_set_encoding('output_encoding', 'UTF-8');
+            iconv_set_encoding('input_encoding', 'UTF-8');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        }
 
         $this->_awsAccessKeyId = $awsAccessKeyId;
         $this->_awsSecretAccessKey = $awsSecretAccessKey;

--- a/src/MarketplaceWebServiceProducts/Client.php
+++ b/src/MarketplaceWebServiceProducts/Client.php
@@ -389,9 +389,11 @@ class MarketplaceWebServiceProducts_Client implements MarketplaceWebServiceProdu
         $applicationVersion,
         $config = null
     ) {
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if(version_compare(PHP_VERSION, '5.6.0', '<')) {
+            iconv_set_encoding('output_encoding', 'UTF-8');
+            iconv_set_encoding('input_encoding', 'UTF-8');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        }
 
         $this->_awsAccessKeyId = $awsAccessKeyId;
         $this->_awsSecretAccessKey = $awsSecretAccessKey;

--- a/src/MarketplaceWebServiceSellers/Client.php
+++ b/src/MarketplaceWebServiceSellers/Client.php
@@ -157,9 +157,11 @@ class MarketplaceWebServiceSellers_Client implements MarketplaceWebServiceSeller
         $applicationVersion,
         $config = null
     ) {
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if(version_compare(PHP_VERSION, '5.6.0', '<')) {
+            iconv_set_encoding('output_encoding', 'UTF-8');
+            iconv_set_encoding('input_encoding', 'UTF-8');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        }
 
         $this->_awsAccessKeyId = $awsAccessKeyId;
         $this->_awsSecretAccessKey = $awsSecretAccessKey;


### PR DESCRIPTION
- Fixed PHP Deprecated:  iconv_set_encoding(): Use of iconv.output_encoding is deprecated for PHP 5.6+ (http://php.net/manual/de/iconv.configuration.php)