### PR TITLE
Fixed a Bug were PHP7+ throws a fatal error

### DIFF
--- a/src/FBAInboundServiceMWS/Model/ResponseHeaderMetadata.php
+++ b/src/FBAInboundServiceMWS/Model/ResponseHeaderMetadata.php
@@ -34,14 +34,14 @@ class FBAInboundServiceMWS_Model_ResponseHeaderMetadata
         $responseContext = null,
         $timestamp = null,
         $quotaMax = null,
-        $quotaMax = null,
+        $quotaRemaining = null,
         $quotaResetsAt = null
     ) {
         $this->metadata[self::REQUEST_ID] = $requestId;
         $this->metadata[self::RESPONSE_CONTEXT] = $responseContext;
         $this->metadata[self::TIMESTAMP] = $timestamp;
         $this->metadata[self::QUOTA_MAX] = $quotaMax;
-        $this->metadata[self::QUOTA_REMAINING] = $quotaMax;
+        $this->metadata[self::QUOTA_REMAINING] = $quotaRemaining;
         $this->metadata[self::QUOTA_RESETS_AT] = $quotaResetsAt;
     }
 

--- a/src/FBAInventoryServiceMWS/Client.php
+++ b/src/FBAInventoryServiceMWS/Client.php
@@ -49,6 +49,8 @@ class FBAInventoryServiceMWS_Client implements FBAInventoryServiceMWS_Interface
         'SSL_VerifyHost' => 2,
     );
 
+    /** @var string */
+    private $_serviceVersion;
 
     /**
      * Get Service Status

--- a/src/FBAInventoryServiceMWS/Model/ResponseHeaderMetadata.php
+++ b/src/FBAInventoryServiceMWS/Model/ResponseHeaderMetadata.php
@@ -34,14 +34,14 @@ class FBAInventoryServiceMWS_Model_ResponseHeaderMetadata
         $responseContext = null,
         $timestamp = null,
         $quotaMax = null,
-        $quotaMax = null,
+        $quotaRemaining = null,
         $quotaResetsAt = null
     ) {
         $this->metadata[self::REQUEST_ID] = $requestId;
         $this->metadata[self::RESPONSE_CONTEXT] = $responseContext;
         $this->metadata[self::TIMESTAMP] = $timestamp;
         $this->metadata[self::QUOTA_MAX] = $quotaMax;
-        $this->metadata[self::QUOTA_REMAINING] = $quotaMax;
+        $this->metadata[self::QUOTA_REMAINING] = $quotaRemaining;
         $this->metadata[self::QUOTA_RESETS_AT] = $quotaResetsAt;
     }
 

--- a/src/FBAOutboundServiceMWS/Model/ResponseHeaderMetadata.php
+++ b/src/FBAOutboundServiceMWS/Model/ResponseHeaderMetadata.php
@@ -34,14 +34,14 @@ class FBAOutboundServiceMWS_Model_ResponseHeaderMetadata
         $responseContext = null,
         $timestamp = null,
         $quotaMax = null,
-        $quotaMax = null,
+        $quotaRemaining = null,
         $quotaResetsAt = null
     ) {
         $this->metadata[self::REQUEST_ID] = $requestId;
         $this->metadata[self::RESPONSE_CONTEXT] = $responseContext;
         $this->metadata[self::TIMESTAMP] = $timestamp;
         $this->metadata[self::QUOTA_MAX] = $quotaMax;
-        $this->metadata[self::QUOTA_REMAINING] = $quotaMax;
+        $this->metadata[self::QUOTA_REMAINING] = $quotaRemaining;
         $this->metadata[self::QUOTA_RESETS_AT] = $quotaResetsAt;
     }
 

--- a/src/MarketplaceWebServiceOrders/Model/ResponseHeaderMetadata.php
+++ b/src/MarketplaceWebServiceOrders/Model/ResponseHeaderMetadata.php
@@ -34,14 +34,14 @@ class MarketplaceWebServiceOrders_Model_ResponseHeaderMetadata
         $responseContext = null,
         $timestamp = null,
         $quotaMax = null,
-        $quotaMax = null,
+        $quotaRemaining = null,
         $quotaResetsAt = null
     ) {
         $this->metadata[self::REQUEST_ID] = $requestId;
         $this->metadata[self::RESPONSE_CONTEXT] = $responseContext;
         $this->metadata[self::TIMESTAMP] = $timestamp;
         $this->metadata[self::QUOTA_MAX] = $quotaMax;
-        $this->metadata[self::QUOTA_REMAINING] = $quotaMax;
+        $this->metadata[self::QUOTA_REMAINING] = $quotaRemaining;
         $this->metadata[self::QUOTA_RESETS_AT] = $quotaResetsAt;
     }
 

--- a/src/MarketplaceWebServiceProducts/Model/ResponseHeaderMetadata.php
+++ b/src/MarketplaceWebServiceProducts/Model/ResponseHeaderMetadata.php
@@ -34,14 +34,14 @@ class MarketplaceWebServiceProducts_Model_ResponseHeaderMetadata
         $responseContext = null,
         $timestamp = null,
         $quotaMax = null,
-        $quotaMax = null,
+        $quotaRemaining = null,
         $quotaResetsAt = null
     ) {
         $this->metadata[self::REQUEST_ID] = $requestId;
         $this->metadata[self::RESPONSE_CONTEXT] = $responseContext;
         $this->metadata[self::TIMESTAMP] = $timestamp;
         $this->metadata[self::QUOTA_MAX] = $quotaMax;
-        $this->metadata[self::QUOTA_REMAINING] = $quotaMax;
+        $this->metadata[self::QUOTA_REMAINING] = $quotaRemaining;
         $this->metadata[self::QUOTA_RESETS_AT] = $quotaResetsAt;
     }
 

--- a/src/MarketplaceWebServiceSellers/Model/ResponseHeaderMetadata.php
+++ b/src/MarketplaceWebServiceSellers/Model/ResponseHeaderMetadata.php
@@ -34,14 +34,14 @@ class MarketplaceWebServiceSellers_Model_ResponseHeaderMetadata
         $responseContext = null,
         $timestamp = null,
         $quotaMax = null,
-        $quotaMax = null,
+        $quotaRemaining = null,
         $quotaResetsAt = null
     ) {
         $this->metadata[self::REQUEST_ID] = $requestId;
         $this->metadata[self::RESPONSE_CONTEXT] = $responseContext;
         $this->metadata[self::TIMESTAMP] = $timestamp;
         $this->metadata[self::QUOTA_MAX] = $quotaMax;
-        $this->metadata[self::QUOTA_REMAINING] = $quotaMax;
+        $this->metadata[self::QUOTA_REMAINING] = $quotaRemaining;
         $this->metadata[self::QUOTA_RESETS_AT] = $quotaResetsAt;
     }
 


### PR DESCRIPTION
- Fixed a Bug were PHP7+ throws a fatal error: `PHP Fatal error:  Redefinition of parameter $quotaMax`. Older Versions of PHP had simply ignored that problem.