### PR TITLE
Fatal error on PHP 7 fix

### DIFF
--- a/src/MarketplaceWebServiceProducts/Model/ResponseHeaderMetadata.php
+++ b/src/MarketplaceWebServiceProducts/Model/ResponseHeaderMetadata.php
@@ -34,7 +34,6 @@ class MarketplaceWebServiceProducts_Model_ResponseHeaderMetadata
         $responseContext = null,
         $timestamp = null,
         $quotaMax = null,
-        $quotaMax = null,
         $quotaResetsAt = null
     ) {
         $this->metadata[self::REQUEST_ID] = $requestId;


### PR DESCRIPTION
Error:
> Fatal error: Redefinition of parameter $a in php shell code on line 1