### PR TITLE
Correct type hinting for @return true -> @return bool

### DIFF
--- a/src/FBAInboundServiceMWS/Model.php
+++ b/src/FBAInboundServiceMWS/Model.php
@@ -404,7 +404,7 @@ abstract class FBAInboundServiceMWS_Model
      * Checks  whether passed variable is an associative array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an associative array
+     * @return bool True if passed variable is an associative array
      */
     private function _isAssociativeArray($var)
     {
@@ -415,7 +415,7 @@ abstract class FBAInboundServiceMWS_Model
      * Checks  whether passed variable is DOMElement
      *
      * @param mixed $var
-     * @return TRUE if passed variable is DOMElement
+     * @return bool True if passed variable is DOMElement
      */
     private function _isDOMElement($var)
     {
@@ -426,7 +426,7 @@ abstract class FBAInboundServiceMWS_Model
      * Checks  whether passed variable is numeric array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an numeric array
+     * @return bool True if passed variable is an numeric array
      */
     protected function _isNumericArray($var)
     {

--- a/src/FBAInboundServiceMWS/Model/ASINPrepInstructions.php
+++ b/src/FBAInboundServiceMWS/Model/ASINPrepInstructions.php
@@ -72,7 +72,7 @@ class FBAInboundServiceMWS_Model_ASINPrepInstructions extends FBAInboundServiceM
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {
@@ -118,7 +118,7 @@ class FBAInboundServiceMWS_Model_ASINPrepInstructions extends FBAInboundServiceM
     /**
      * Check to see if BarcodeInstruction is set.
      *
-     * @return true if BarcodeInstruction is set.
+     * @return bool True if BarcodeInstruction is set.
      */
     public function isSetBarcodeInstruction()
     {
@@ -164,7 +164,7 @@ class FBAInboundServiceMWS_Model_ASINPrepInstructions extends FBAInboundServiceM
     /**
      * Check to see if PrepGuidance is set.
      *
-     * @return true if PrepGuidance is set.
+     * @return bool True if PrepGuidance is set.
      */
     public function isSetPrepGuidance()
     {
@@ -210,7 +210,7 @@ class FBAInboundServiceMWS_Model_ASINPrepInstructions extends FBAInboundServiceM
     /**
      * Check to see if PrepInstructionList is set.
      *
-     * @return true if PrepInstructionList is set.
+     * @return bool True if PrepInstructionList is set.
      */
     public function isSetPrepInstructionList()
     {

--- a/src/FBAInboundServiceMWS/Model/ASINPrepInstructionsList.php
+++ b/src/FBAInboundServiceMWS/Model/ASINPrepInstructionsList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_ASINPrepInstructionsList extends FBAInboundServ
     /**
      * Check to see if ASINPrepInstructions is set.
      *
-     * @return true if ASINPrepInstructions is set.
+     * @return bool True if ASINPrepInstructions is set.
      */
     public function isSetASINPrepInstructions()
     {

--- a/src/FBAInboundServiceMWS/Model/Address.php
+++ b/src/FBAInboundServiceMWS/Model/Address.php
@@ -77,7 +77,7 @@ class FBAInboundServiceMWS_Model_Address extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Name is set.
      *
-     * @return true if Name is set.
+     * @return bool True if Name is set.
      */
     public function isSetName()
     {
@@ -123,7 +123,7 @@ class FBAInboundServiceMWS_Model_Address extends FBAInboundServiceMWS_Model
     /**
      * Check to see if AddressLine1 is set.
      *
-     * @return true if AddressLine1 is set.
+     * @return bool True if AddressLine1 is set.
      */
     public function isSetAddressLine1()
     {
@@ -169,7 +169,7 @@ class FBAInboundServiceMWS_Model_Address extends FBAInboundServiceMWS_Model
     /**
      * Check to see if AddressLine2 is set.
      *
-     * @return true if AddressLine2 is set.
+     * @return bool True if AddressLine2 is set.
      */
     public function isSetAddressLine2()
     {
@@ -215,7 +215,7 @@ class FBAInboundServiceMWS_Model_Address extends FBAInboundServiceMWS_Model
     /**
      * Check to see if DistrictOrCounty is set.
      *
-     * @return true if DistrictOrCounty is set.
+     * @return bool True if DistrictOrCounty is set.
      */
     public function isSetDistrictOrCounty()
     {
@@ -261,7 +261,7 @@ class FBAInboundServiceMWS_Model_Address extends FBAInboundServiceMWS_Model
     /**
      * Check to see if City is set.
      *
-     * @return true if City is set.
+     * @return bool True if City is set.
      */
     public function isSetCity()
     {
@@ -307,7 +307,7 @@ class FBAInboundServiceMWS_Model_Address extends FBAInboundServiceMWS_Model
     /**
      * Check to see if StateOrProvinceCode is set.
      *
-     * @return true if StateOrProvinceCode is set.
+     * @return bool True if StateOrProvinceCode is set.
      */
     public function isSetStateOrProvinceCode()
     {
@@ -353,7 +353,7 @@ class FBAInboundServiceMWS_Model_Address extends FBAInboundServiceMWS_Model
     /**
      * Check to see if CountryCode is set.
      *
-     * @return true if CountryCode is set.
+     * @return bool True if CountryCode is set.
      */
     public function isSetCountryCode()
     {
@@ -399,7 +399,7 @@ class FBAInboundServiceMWS_Model_Address extends FBAInboundServiceMWS_Model
     /**
      * Check to see if PostalCode is set.
      *
-     * @return true if PostalCode is set.
+     * @return bool True if PostalCode is set.
      */
     public function isSetPostalCode()
     {

--- a/src/FBAInboundServiceMWS/Model/Amount.php
+++ b/src/FBAInboundServiceMWS/Model/Amount.php
@@ -65,7 +65,7 @@ class FBAInboundServiceMWS_Model_Amount extends FBAInboundServiceMWS_Model
     /**
      * Check to see if CurrencyCode is set.
      *
-     * @return true if CurrencyCode is set.
+     * @return bool True if CurrencyCode is set.
      */
     public function isSetCurrencyCode()
     {
@@ -111,7 +111,7 @@ class FBAInboundServiceMWS_Model_Amount extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Value is set.
      *
-     * @return true if Value is set.
+     * @return bool True if Value is set.
      */
     public function isSetValue()
     {

--- a/src/FBAInboundServiceMWS/Model/AsinList.php
+++ b/src/FBAInboundServiceMWS/Model/AsinList.php
@@ -77,7 +77,7 @@ class FBAInboundServiceMWS_Model_AsinList extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Id is set.
      *
-     * @return true if Id is set.
+     * @return bool True if Id is set.
      */
     public function isSetId()
     {

--- a/src/FBAInboundServiceMWS/Model/ConfirmTransportInputRequest.php
+++ b/src/FBAInboundServiceMWS/Model/ConfirmTransportInputRequest.php
@@ -67,7 +67,7 @@ class FBAInboundServiceMWS_Model_ConfirmTransportInputRequest extends FBAInbound
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class FBAInboundServiceMWS_Model_ConfirmTransportInputRequest extends FBAInbound
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class FBAInboundServiceMWS_Model_ConfirmTransportInputRequest extends FBAInbound
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {

--- a/src/FBAInboundServiceMWS/Model/ConfirmTransportRequestResponse.php
+++ b/src/FBAInboundServiceMWS/Model/ConfirmTransportRequestResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_ConfirmTransportRequestResponse extends FBAInbo
     /**
      * Check to see if ConfirmTransportRequestResult is set.
      *
-     * @return true if ConfirmTransportRequestResult is set.
+     * @return bool True if ConfirmTransportRequestResult is set.
      */
     public function isSetConfirmTransportRequestResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_ConfirmTransportRequestResponse extends FBAInbo
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_ConfirmTransportRequestResponse extends FBAInbo
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/ConfirmTransportRequestResult.php
+++ b/src/FBAInboundServiceMWS/Model/ConfirmTransportRequestResult.php
@@ -66,7 +66,7 @@ class FBAInboundServiceMWS_Model_ConfirmTransportRequestResult extends FBAInboun
     /**
      * Check to see if TransportResult is set.
      *
-     * @return true if TransportResult is set.
+     * @return bool True if TransportResult is set.
      */
     public function isSetTransportResult()
     {

--- a/src/FBAInboundServiceMWS/Model/Contact.php
+++ b/src/FBAInboundServiceMWS/Model/Contact.php
@@ -69,7 +69,7 @@ class FBAInboundServiceMWS_Model_Contact extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Name is set.
      *
-     * @return true if Name is set.
+     * @return bool True if Name is set.
      */
     public function isSetName()
     {
@@ -115,7 +115,7 @@ class FBAInboundServiceMWS_Model_Contact extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Phone is set.
      *
-     * @return true if Phone is set.
+     * @return bool True if Phone is set.
      */
     public function isSetPhone()
     {
@@ -161,7 +161,7 @@ class FBAInboundServiceMWS_Model_Contact extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Email is set.
      *
-     * @return true if Email is set.
+     * @return bool True if Email is set.
      */
     public function isSetEmail()
     {
@@ -207,7 +207,7 @@ class FBAInboundServiceMWS_Model_Contact extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Fax is set.
      *
-     * @return true if Fax is set.
+     * @return bool True if Fax is set.
      */
     public function isSetFax()
     {

--- a/src/FBAInboundServiceMWS/Model/CreateInboundShipmentPlanRequest.php
+++ b/src/FBAInboundServiceMWS/Model/CreateInboundShipmentPlanRequest.php
@@ -78,7 +78,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentPlanRequest extends FBAInb
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -124,7 +124,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentPlanRequest extends FBAInb
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -170,7 +170,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentPlanRequest extends FBAInb
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -216,7 +216,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentPlanRequest extends FBAInb
     /**
      * Check to see if ShipFromAddress is set.
      *
-     * @return true if ShipFromAddress is set.
+     * @return bool True if ShipFromAddress is set.
      */
     public function isSetShipFromAddress()
     {
@@ -262,7 +262,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentPlanRequest extends FBAInb
     /**
      * Check to see if LabelPrepPreference is set.
      *
-     * @return true if LabelPrepPreference is set.
+     * @return bool True if LabelPrepPreference is set.
      */
     public function isSetLabelPrepPreference()
     {
@@ -308,7 +308,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentPlanRequest extends FBAInb
     /**
      * Check to see if ShipToCountryCode is set.
      *
-     * @return true if ShipToCountryCode is set.
+     * @return bool True if ShipToCountryCode is set.
      */
     public function isSetShipToCountryCode()
     {
@@ -354,7 +354,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentPlanRequest extends FBAInb
     /**
      * Check to see if InboundShipmentPlanRequestItems is set.
      *
-     * @return true if InboundShipmentPlanRequestItems is set.
+     * @return bool True if InboundShipmentPlanRequestItems is set.
      */
     public function isSetInboundShipmentPlanRequestItems()
     {

--- a/src/FBAInboundServiceMWS/Model/CreateInboundShipmentPlanResponse.php
+++ b/src/FBAInboundServiceMWS/Model/CreateInboundShipmentPlanResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentPlanResponse extends FBAIn
     /**
      * Check to see if CreateInboundShipmentPlanResult is set.
      *
-     * @return true if CreateInboundShipmentPlanResult is set.
+     * @return bool True if CreateInboundShipmentPlanResult is set.
      */
     public function isSetCreateInboundShipmentPlanResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentPlanResponse extends FBAIn
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentPlanResponse extends FBAIn
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/CreateInboundShipmentPlanResult.php
+++ b/src/FBAInboundServiceMWS/Model/CreateInboundShipmentPlanResult.php
@@ -66,7 +66,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentPlanResult extends FBAInbo
     /**
      * Check to see if InboundShipmentPlans is set.
      *
-     * @return true if InboundShipmentPlans is set.
+     * @return bool True if InboundShipmentPlans is set.
      */
     public function isSetInboundShipmentPlans()
     {

--- a/src/FBAInboundServiceMWS/Model/CreateInboundShipmentRequest.php
+++ b/src/FBAInboundServiceMWS/Model/CreateInboundShipmentRequest.php
@@ -79,7 +79,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -125,7 +125,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -171,7 +171,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -217,7 +217,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {
@@ -263,7 +263,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if InboundShipmentHeader is set.
      *
-     * @return true if InboundShipmentHeader is set.
+     * @return bool True if InboundShipmentHeader is set.
      */
     public function isSetInboundShipmentHeader()
     {
@@ -309,7 +309,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if InboundShipmentItems is set.
      *
-     * @return true if InboundShipmentItems is set.
+     * @return bool True if InboundShipmentItems is set.
      */
     public function isSetInboundShipmentItems()
     {

--- a/src/FBAInboundServiceMWS/Model/CreateInboundShipmentResponse.php
+++ b/src/FBAInboundServiceMWS/Model/CreateInboundShipmentResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentResponse extends FBAInboun
     /**
      * Check to see if CreateInboundShipmentResult is set.
      *
-     * @return true if CreateInboundShipmentResult is set.
+     * @return bool True if CreateInboundShipmentResult is set.
      */
     public function isSetCreateInboundShipmentResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentResponse extends FBAInboun
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentResponse extends FBAInboun
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/CreateInboundShipmentResult.php
+++ b/src/FBAInboundServiceMWS/Model/CreateInboundShipmentResult.php
@@ -63,7 +63,7 @@ class FBAInboundServiceMWS_Model_CreateInboundShipmentResult extends FBAInboundS
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {

--- a/src/FBAInboundServiceMWS/Model/Dimensions.php
+++ b/src/FBAInboundServiceMWS/Model/Dimensions.php
@@ -69,7 +69,7 @@ class FBAInboundServiceMWS_Model_Dimensions extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Length is set.
      *
-     * @return true if Length is set.
+     * @return bool True if Length is set.
      */
     public function isSetLength()
     {
@@ -115,7 +115,7 @@ class FBAInboundServiceMWS_Model_Dimensions extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Width is set.
      *
-     * @return true if Width is set.
+     * @return bool True if Width is set.
      */
     public function isSetWidth()
     {
@@ -161,7 +161,7 @@ class FBAInboundServiceMWS_Model_Dimensions extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Height is set.
      *
-     * @return true if Height is set.
+     * @return bool True if Height is set.
      */
     public function isSetHeight()
     {
@@ -207,7 +207,7 @@ class FBAInboundServiceMWS_Model_Dimensions extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Unit is set.
      *
-     * @return true if Unit is set.
+     * @return bool True if Unit is set.
      */
     public function isSetUnit()
     {

--- a/src/FBAInboundServiceMWS/Model/EstimateTransportInputRequest.php
+++ b/src/FBAInboundServiceMWS/Model/EstimateTransportInputRequest.php
@@ -67,7 +67,7 @@ class FBAInboundServiceMWS_Model_EstimateTransportInputRequest extends FBAInboun
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class FBAInboundServiceMWS_Model_EstimateTransportInputRequest extends FBAInboun
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class FBAInboundServiceMWS_Model_EstimateTransportInputRequest extends FBAInboun
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {

--- a/src/FBAInboundServiceMWS/Model/EstimateTransportRequestResponse.php
+++ b/src/FBAInboundServiceMWS/Model/EstimateTransportRequestResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_EstimateTransportRequestResponse extends FBAInb
     /**
      * Check to see if EstimateTransportRequestResult is set.
      *
-     * @return true if EstimateTransportRequestResult is set.
+     * @return bool True if EstimateTransportRequestResult is set.
      */
     public function isSetEstimateTransportRequestResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_EstimateTransportRequestResponse extends FBAInb
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_EstimateTransportRequestResponse extends FBAInb
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/EstimateTransportRequestResult.php
+++ b/src/FBAInboundServiceMWS/Model/EstimateTransportRequestResult.php
@@ -66,7 +66,7 @@ class FBAInboundServiceMWS_Model_EstimateTransportRequestResult extends FBAInbou
     /**
      * Check to see if TransportResult is set.
      *
-     * @return true if TransportResult is set.
+     * @return bool True if TransportResult is set.
      */
     public function isSetTransportResult()
     {

--- a/src/FBAInboundServiceMWS/Model/GetBillOfLadingRequest.php
+++ b/src/FBAInboundServiceMWS/Model/GetBillOfLadingRequest.php
@@ -67,7 +67,7 @@ class FBAInboundServiceMWS_Model_GetBillOfLadingRequest extends FBAInboundServic
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class FBAInboundServiceMWS_Model_GetBillOfLadingRequest extends FBAInboundServic
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class FBAInboundServiceMWS_Model_GetBillOfLadingRequest extends FBAInboundServic
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {

--- a/src/FBAInboundServiceMWS/Model/GetBillOfLadingResponse.php
+++ b/src/FBAInboundServiceMWS/Model/GetBillOfLadingResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_GetBillOfLadingResponse extends FBAInboundServi
     /**
      * Check to see if GetBillOfLadingResult is set.
      *
-     * @return true if GetBillOfLadingResult is set.
+     * @return bool True if GetBillOfLadingResult is set.
      */
     public function isSetGetBillOfLadingResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_GetBillOfLadingResponse extends FBAInboundServi
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_GetBillOfLadingResponse extends FBAInboundServi
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/GetBillOfLadingResult.php
+++ b/src/FBAInboundServiceMWS/Model/GetBillOfLadingResult.php
@@ -66,7 +66,7 @@ class FBAInboundServiceMWS_Model_GetBillOfLadingResult extends FBAInboundService
     /**
      * Check to see if TransportDocument is set.
      *
-     * @return true if TransportDocument is set.
+     * @return bool True if TransportDocument is set.
      */
     public function isSetTransportDocument()
     {

--- a/src/FBAInboundServiceMWS/Model/GetPackageLabelsRequest.php
+++ b/src/FBAInboundServiceMWS/Model/GetPackageLabelsRequest.php
@@ -71,7 +71,7 @@ class FBAInboundServiceMWS_Model_GetPackageLabelsRequest extends FBAInboundServi
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -117,7 +117,7 @@ class FBAInboundServiceMWS_Model_GetPackageLabelsRequest extends FBAInboundServi
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -163,7 +163,7 @@ class FBAInboundServiceMWS_Model_GetPackageLabelsRequest extends FBAInboundServi
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {
@@ -209,7 +209,7 @@ class FBAInboundServiceMWS_Model_GetPackageLabelsRequest extends FBAInboundServi
     /**
      * Check to see if PageType is set.
      *
-     * @return true if PageType is set.
+     * @return bool True if PageType is set.
      */
     public function isSetPageType()
     {
@@ -255,7 +255,7 @@ class FBAInboundServiceMWS_Model_GetPackageLabelsRequest extends FBAInboundServi
     /**
      * Check to see if NumberOfPackages is set.
      *
-     * @return true if NumberOfPackages is set.
+     * @return bool True if NumberOfPackages is set.
      */
     public function isSetNumberOfPackages()
     {

--- a/src/FBAInboundServiceMWS/Model/GetPackageLabelsResponse.php
+++ b/src/FBAInboundServiceMWS/Model/GetPackageLabelsResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_GetPackageLabelsResponse extends FBAInboundServ
     /**
      * Check to see if GetPackageLabelsResult is set.
      *
-     * @return true if GetPackageLabelsResult is set.
+     * @return bool True if GetPackageLabelsResult is set.
      */
     public function isSetGetPackageLabelsResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_GetPackageLabelsResponse extends FBAInboundServ
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_GetPackageLabelsResponse extends FBAInboundServ
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/GetPackageLabelsResult.php
+++ b/src/FBAInboundServiceMWS/Model/GetPackageLabelsResult.php
@@ -66,7 +66,7 @@ class FBAInboundServiceMWS_Model_GetPackageLabelsResult extends FBAInboundServic
     /**
      * Check to see if TransportDocument is set.
      *
-     * @return true if TransportDocument is set.
+     * @return bool True if TransportDocument is set.
      */
     public function isSetTransportDocument()
     {

--- a/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForASINRequest.php
+++ b/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForASINRequest.php
@@ -69,7 +69,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForASINRequest extends FBAIn
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -115,7 +115,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForASINRequest extends FBAIn
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -161,7 +161,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForASINRequest extends FBAIn
     /**
      * Check to see if AsinList is set.
      *
-     * @return true if AsinList is set.
+     * @return bool True if AsinList is set.
      */
     public function isSetAsinList()
     {
@@ -207,7 +207,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForASINRequest extends FBAIn
     /**
      * Check to see if ShipToCountryCode is set.
      *
-     * @return true if ShipToCountryCode is set.
+     * @return bool True if ShipToCountryCode is set.
      */
     public function isSetShipToCountryCode()
     {

--- a/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForASINResponse.php
+++ b/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForASINResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForASINResponse extends FBAI
     /**
      * Check to see if GetPrepInstructionsForASINResult is set.
      *
-     * @return true if GetPrepInstructionsForASINResult is set.
+     * @return bool True if GetPrepInstructionsForASINResult is set.
      */
     public function isSetGetPrepInstructionsForASINResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForASINResponse extends FBAI
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForASINResponse extends FBAI
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForASINResult.php
+++ b/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForASINResult.php
@@ -71,7 +71,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForASINResult extends FBAInb
     /**
      * Check to see if ASINPrepInstructionsList is set.
      *
-     * @return true if ASINPrepInstructionsList is set.
+     * @return bool True if ASINPrepInstructionsList is set.
      */
     public function isSetASINPrepInstructionsList()
     {
@@ -117,7 +117,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForASINResult extends FBAInb
     /**
      * Check to see if InvalidASINList is set.
      *
-     * @return true if InvalidASINList is set.
+     * @return bool True if InvalidASINList is set.
      */
     public function isSetInvalidASINList()
     {

--- a/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForSKURequest.php
+++ b/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForSKURequest.php
@@ -69,7 +69,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForSKURequest extends FBAInb
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -115,7 +115,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForSKURequest extends FBAInb
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -161,7 +161,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForSKURequest extends FBAInb
     /**
      * Check to see if SellerSKUList is set.
      *
-     * @return true if SellerSKUList is set.
+     * @return bool True if SellerSKUList is set.
      */
     public function isSetSellerSKUList()
     {
@@ -207,7 +207,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForSKURequest extends FBAInb
     /**
      * Check to see if ShipToCountryCode is set.
      *
-     * @return true if ShipToCountryCode is set.
+     * @return bool True if ShipToCountryCode is set.
      */
     public function isSetShipToCountryCode()
     {

--- a/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForSKUResponse.php
+++ b/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForSKUResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForSKUResponse extends FBAIn
     /**
      * Check to see if GetPrepInstructionsForSKUResult is set.
      *
-     * @return true if GetPrepInstructionsForSKUResult is set.
+     * @return bool True if GetPrepInstructionsForSKUResult is set.
      */
     public function isSetGetPrepInstructionsForSKUResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForSKUResponse extends FBAIn
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForSKUResponse extends FBAIn
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForSKUResult.php
+++ b/src/FBAInboundServiceMWS/Model/GetPrepInstructionsForSKUResult.php
@@ -68,7 +68,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForSKUResult extends FBAInbo
     /**
      * Check to see if SKUPrepInstructionsList is set.
      *
-     * @return true if SKUPrepInstructionsList is set.
+     * @return bool True if SKUPrepInstructionsList is set.
      */
     public function isSetSKUPrepInstructionsList()
     {
@@ -114,7 +114,7 @@ class FBAInboundServiceMWS_Model_GetPrepInstructionsForSKUResult extends FBAInbo
     /**
      * Check to see if InvalidSKUList is set.
      *
-     * @return true if InvalidSKUList is set.
+     * @return bool True if InvalidSKUList is set.
      */
     public function isSetInvalidSKUList()
     {

--- a/src/FBAInboundServiceMWS/Model/GetServiceStatusRequest.php
+++ b/src/FBAInboundServiceMWS/Model/GetServiceStatusRequest.php
@@ -67,7 +67,7 @@ class FBAInboundServiceMWS_Model_GetServiceStatusRequest extends FBAInboundServi
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class FBAInboundServiceMWS_Model_GetServiceStatusRequest extends FBAInboundServi
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class FBAInboundServiceMWS_Model_GetServiceStatusRequest extends FBAInboundServi
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {

--- a/src/FBAInboundServiceMWS/Model/GetServiceStatusResponse.php
+++ b/src/FBAInboundServiceMWS/Model/GetServiceStatusResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_GetServiceStatusResponse extends FBAInboundServ
     /**
      * Check to see if GetServiceStatusResult is set.
      *
-     * @return true if GetServiceStatusResult is set.
+     * @return bool True if GetServiceStatusResult is set.
      */
     public function isSetGetServiceStatusResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_GetServiceStatusResponse extends FBAInboundServ
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_GetServiceStatusResponse extends FBAInboundServ
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/GetServiceStatusResult.php
+++ b/src/FBAInboundServiceMWS/Model/GetServiceStatusResult.php
@@ -65,7 +65,7 @@ class FBAInboundServiceMWS_Model_GetServiceStatusResult extends FBAInboundServic
     /**
      * Check to see if Status is set.
      *
-     * @return true if Status is set.
+     * @return bool True if Status is set.
      */
     public function isSetStatus()
     {
@@ -111,7 +111,7 @@ class FBAInboundServiceMWS_Model_GetServiceStatusResult extends FBAInboundServic
     /**
      * Check to see if Timestamp is set.
      *
-     * @return true if Timestamp is set.
+     * @return bool True if Timestamp is set.
      */
     public function isSetTimestamp()
     {

--- a/src/FBAInboundServiceMWS/Model/GetTransportContentRequest.php
+++ b/src/FBAInboundServiceMWS/Model/GetTransportContentRequest.php
@@ -67,7 +67,7 @@ class FBAInboundServiceMWS_Model_GetTransportContentRequest extends FBAInboundSe
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class FBAInboundServiceMWS_Model_GetTransportContentRequest extends FBAInboundSe
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class FBAInboundServiceMWS_Model_GetTransportContentRequest extends FBAInboundSe
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {

--- a/src/FBAInboundServiceMWS/Model/GetTransportContentResponse.php
+++ b/src/FBAInboundServiceMWS/Model/GetTransportContentResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_GetTransportContentResponse extends FBAInboundS
     /**
      * Check to see if GetTransportContentResult is set.
      *
-     * @return true if GetTransportContentResult is set.
+     * @return bool True if GetTransportContentResult is set.
      */
     public function isSetGetTransportContentResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_GetTransportContentResponse extends FBAInboundS
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_GetTransportContentResponse extends FBAInboundS
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/GetTransportContentResult.php
+++ b/src/FBAInboundServiceMWS/Model/GetTransportContentResult.php
@@ -66,7 +66,7 @@ class FBAInboundServiceMWS_Model_GetTransportContentResult extends FBAInboundSer
     /**
      * Check to see if TransportContent is set.
      *
-     * @return true if TransportContent is set.
+     * @return bool True if TransportContent is set.
      */
     public function isSetTransportContent()
     {

--- a/src/FBAInboundServiceMWS/Model/InboundShipmentHeader.php
+++ b/src/FBAInboundServiceMWS/Model/InboundShipmentHeader.php
@@ -73,7 +73,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentHeader extends FBAInboundService
     /**
      * Check to see if ShipmentName is set.
      *
-     * @return true if ShipmentName is set.
+     * @return bool True if ShipmentName is set.
      */
     public function isSetShipmentName()
     {
@@ -119,7 +119,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentHeader extends FBAInboundService
     /**
      * Check to see if ShipFromAddress is set.
      *
-     * @return true if ShipFromAddress is set.
+     * @return bool True if ShipFromAddress is set.
      */
     public function isSetShipFromAddress()
     {
@@ -165,7 +165,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentHeader extends FBAInboundService
     /**
      * Check to see if DestinationFulfillmentCenterId is set.
      *
-     * @return true if DestinationFulfillmentCenterId is set.
+     * @return bool True if DestinationFulfillmentCenterId is set.
      */
     public function isSetDestinationFulfillmentCenterId()
     {
@@ -189,7 +189,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentHeader extends FBAInboundService
     /**
      * Check the value of AreCasesRequired.
      *
-     * @return true if AreCasesRequired is set to true.
+     * @return bool True if AreCasesRequired is set to true.
      */
     public function isAreCasesRequired()
     {
@@ -221,7 +221,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentHeader extends FBAInboundService
     /**
      * Check to see if AreCasesRequired is set.
      *
-     * @return true if AreCasesRequired is set.
+     * @return bool True if AreCasesRequired is set.
      */
     public function isSetAreCasesRequired()
     {
@@ -267,7 +267,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentHeader extends FBAInboundService
     /**
      * Check to see if ShipmentStatus is set.
      *
-     * @return true if ShipmentStatus is set.
+     * @return bool True if ShipmentStatus is set.
      */
     public function isSetShipmentStatus()
     {
@@ -313,7 +313,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentHeader extends FBAInboundService
     /**
      * Check to see if LabelPrepPreference is set.
      *
-     * @return true if LabelPrepPreference is set.
+     * @return bool True if LabelPrepPreference is set.
      */
     public function isSetLabelPrepPreference()
     {

--- a/src/FBAInboundServiceMWS/Model/InboundShipmentInfo.php
+++ b/src/FBAInboundServiceMWS/Model/InboundShipmentInfo.php
@@ -75,7 +75,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentInfo extends FBAInboundServiceMW
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {
@@ -121,7 +121,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentInfo extends FBAInboundServiceMW
     /**
      * Check to see if ShipmentName is set.
      *
-     * @return true if ShipmentName is set.
+     * @return bool True if ShipmentName is set.
      */
     public function isSetShipmentName()
     {
@@ -167,7 +167,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentInfo extends FBAInboundServiceMW
     /**
      * Check to see if ShipFromAddress is set.
      *
-     * @return true if ShipFromAddress is set.
+     * @return bool True if ShipFromAddress is set.
      */
     public function isSetShipFromAddress()
     {
@@ -213,7 +213,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentInfo extends FBAInboundServiceMW
     /**
      * Check to see if DestinationFulfillmentCenterId is set.
      *
-     * @return true if DestinationFulfillmentCenterId is set.
+     * @return bool True if DestinationFulfillmentCenterId is set.
      */
     public function isSetDestinationFulfillmentCenterId()
     {
@@ -259,7 +259,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentInfo extends FBAInboundServiceMW
     /**
      * Check to see if ShipmentStatus is set.
      *
-     * @return true if ShipmentStatus is set.
+     * @return bool True if ShipmentStatus is set.
      */
     public function isSetShipmentStatus()
     {
@@ -305,7 +305,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentInfo extends FBAInboundServiceMW
     /**
      * Check to see if LabelPrepType is set.
      *
-     * @return true if LabelPrepType is set.
+     * @return bool True if LabelPrepType is set.
      */
     public function isSetLabelPrepType()
     {
@@ -329,7 +329,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentInfo extends FBAInboundServiceMW
     /**
      * Check the value of AreCasesRequired.
      *
-     * @return true if AreCasesRequired is set to true.
+     * @return bool True if AreCasesRequired is set to true.
      */
     public function isAreCasesRequired()
     {
@@ -361,7 +361,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentInfo extends FBAInboundServiceMW
     /**
      * Check to see if AreCasesRequired is set.
      *
-     * @return true if AreCasesRequired is set.
+     * @return bool True if AreCasesRequired is set.
      */
     public function isSetAreCasesRequired()
     {

--- a/src/FBAInboundServiceMWS/Model/InboundShipmentItem.php
+++ b/src/FBAInboundServiceMWS/Model/InboundShipmentItem.php
@@ -73,7 +73,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentItem extends FBAInboundServiceMW
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {
@@ -119,7 +119,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentItem extends FBAInboundServiceMW
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -165,7 +165,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentItem extends FBAInboundServiceMW
     /**
      * Check to see if FulfillmentNetworkSKU is set.
      *
-     * @return true if FulfillmentNetworkSKU is set.
+     * @return bool True if FulfillmentNetworkSKU is set.
      */
     public function isSetFulfillmentNetworkSKU()
     {
@@ -211,7 +211,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentItem extends FBAInboundServiceMW
     /**
      * Check to see if QuantityShipped is set.
      *
-     * @return true if QuantityShipped is set.
+     * @return bool True if QuantityShipped is set.
      */
     public function isSetQuantityShipped()
     {
@@ -257,7 +257,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentItem extends FBAInboundServiceMW
     /**
      * Check to see if QuantityReceived is set.
      *
-     * @return true if QuantityReceived is set.
+     * @return bool True if QuantityReceived is set.
      */
     public function isSetQuantityReceived()
     {
@@ -303,7 +303,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentItem extends FBAInboundServiceMW
     /**
      * Check to see if QuantityInCase is set.
      *
-     * @return true if QuantityInCase is set.
+     * @return bool True if QuantityInCase is set.
      */
     public function isSetQuantityInCase()
     {

--- a/src/FBAInboundServiceMWS/Model/InboundShipmentItemList.php
+++ b/src/FBAInboundServiceMWS/Model/InboundShipmentItemList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentItemList extends FBAInboundServi
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/InboundShipmentList.php
+++ b/src/FBAInboundServiceMWS/Model/InboundShipmentList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentList extends FBAInboundServiceMW
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/InboundShipmentPlan.php
+++ b/src/FBAInboundServiceMWS/Model/InboundShipmentPlan.php
@@ -74,7 +74,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlan extends FBAInboundServiceMW
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {
@@ -120,7 +120,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlan extends FBAInboundServiceMW
     /**
      * Check to see if DestinationFulfillmentCenterId is set.
      *
-     * @return true if DestinationFulfillmentCenterId is set.
+     * @return bool True if DestinationFulfillmentCenterId is set.
      */
     public function isSetDestinationFulfillmentCenterId()
     {
@@ -166,7 +166,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlan extends FBAInboundServiceMW
     /**
      * Check to see if ShipToAddress is set.
      *
-     * @return true if ShipToAddress is set.
+     * @return bool True if ShipToAddress is set.
      */
     public function isSetShipToAddress()
     {
@@ -212,7 +212,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlan extends FBAInboundServiceMW
     /**
      * Check to see if LabelPrepType is set.
      *
-     * @return true if LabelPrepType is set.
+     * @return bool True if LabelPrepType is set.
      */
     public function isSetLabelPrepType()
     {
@@ -258,7 +258,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlan extends FBAInboundServiceMW
     /**
      * Check to see if Items is set.
      *
-     * @return true if Items is set.
+     * @return bool True if Items is set.
      */
     public function isSetItems()
     {

--- a/src/FBAInboundServiceMWS/Model/InboundShipmentPlanItem.php
+++ b/src/FBAInboundServiceMWS/Model/InboundShipmentPlanItem.php
@@ -67,7 +67,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlanItem extends FBAInboundServi
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -113,7 +113,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlanItem extends FBAInboundServi
     /**
      * Check to see if FulfillmentNetworkSKU is set.
      *
-     * @return true if FulfillmentNetworkSKU is set.
+     * @return bool True if FulfillmentNetworkSKU is set.
      */
     public function isSetFulfillmentNetworkSKU()
     {
@@ -159,7 +159,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlanItem extends FBAInboundServi
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {

--- a/src/FBAInboundServiceMWS/Model/InboundShipmentPlanItemList.php
+++ b/src/FBAInboundServiceMWS/Model/InboundShipmentPlanItemList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlanItemList extends FBAInboundS
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/InboundShipmentPlanList.php
+++ b/src/FBAInboundServiceMWS/Model/InboundShipmentPlanList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlanList extends FBAInboundServi
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/InboundShipmentPlanRequestItem.php
+++ b/src/FBAInboundServiceMWS/Model/InboundShipmentPlanRequestItem.php
@@ -71,7 +71,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlanRequestItem extends FBAInbou
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -117,7 +117,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlanRequestItem extends FBAInbou
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {
@@ -163,7 +163,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlanRequestItem extends FBAInbou
     /**
      * Check to see if Condition is set.
      *
-     * @return true if Condition is set.
+     * @return bool True if Condition is set.
      */
     public function isSetCondition()
     {
@@ -209,7 +209,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlanRequestItem extends FBAInbou
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {
@@ -255,7 +255,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlanRequestItem extends FBAInbou
     /**
      * Check to see if QuantityInCase is set.
      *
-     * @return true if QuantityInCase is set.
+     * @return bool True if QuantityInCase is set.
      */
     public function isSetQuantityInCase()
     {

--- a/src/FBAInboundServiceMWS/Model/InboundShipmentPlanRequestItemList.php
+++ b/src/FBAInboundServiceMWS/Model/InboundShipmentPlanRequestItemList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_InboundShipmentPlanRequestItemList extends FBAI
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/InvalidASIN.php
+++ b/src/FBAInboundServiceMWS/Model/InvalidASIN.php
@@ -65,7 +65,7 @@ class FBAInboundServiceMWS_Model_InvalidASIN extends FBAInboundServiceMWS_Model
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {
@@ -111,7 +111,7 @@ class FBAInboundServiceMWS_Model_InvalidASIN extends FBAInboundServiceMWS_Model
     /**
      * Check to see if ErrorReason is set.
      *
-     * @return true if ErrorReason is set.
+     * @return bool True if ErrorReason is set.
      */
     public function isSetErrorReason()
     {

--- a/src/FBAInboundServiceMWS/Model/InvalidASINList.php
+++ b/src/FBAInboundServiceMWS/Model/InvalidASINList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_InvalidASINList extends FBAInboundServiceMWS_Mo
     /**
      * Check to see if InvalidASIN is set.
      *
-     * @return true if InvalidASIN is set.
+     * @return bool True if InvalidASIN is set.
      */
     public function isSetInvalidASIN()
     {

--- a/src/FBAInboundServiceMWS/Model/InvalidSKU.php
+++ b/src/FBAInboundServiceMWS/Model/InvalidSKU.php
@@ -65,7 +65,7 @@ class FBAInboundServiceMWS_Model_InvalidSKU extends FBAInboundServiceMWS_Model
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -111,7 +111,7 @@ class FBAInboundServiceMWS_Model_InvalidSKU extends FBAInboundServiceMWS_Model
     /**
      * Check to see if ErrorReason is set.
      *
-     * @return true if ErrorReason is set.
+     * @return bool True if ErrorReason is set.
      */
     public function isSetErrorReason()
     {

--- a/src/FBAInboundServiceMWS/Model/InvalidSKUList.php
+++ b/src/FBAInboundServiceMWS/Model/InvalidSKUList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_InvalidSKUList extends FBAInboundServiceMWS_Mod
     /**
      * Check to see if InvalidSKU is set.
      *
-     * @return true if InvalidSKU is set.
+     * @return bool True if InvalidSKU is set.
      */
     public function isSetInvalidSKU()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsByNextTokenRequest.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsByNextTokenRequest.php
@@ -69,7 +69,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsByNextTokenRequest exte
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -115,7 +115,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsByNextTokenRequest exte
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -161,7 +161,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsByNextTokenRequest exte
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -207,7 +207,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsByNextTokenRequest exte
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsByNextTokenResponse.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsByNextTokenResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsByNextTokenResponse ext
     /**
      * Check to see if ListInboundShipmentItemsByNextTokenResult is set.
      *
-     * @return true if ListInboundShipmentItemsByNextTokenResult is set.
+     * @return bool True if ListInboundShipmentItemsByNextTokenResult is set.
      */
     public function isSetListInboundShipmentItemsByNextTokenResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsByNextTokenResponse ext
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsByNextTokenResponse ext
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsByNextTokenResult.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsByNextTokenResult.php
@@ -68,7 +68,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsByNextTokenResult exten
     /**
      * Check to see if ItemData is set.
      *
-     * @return true if ItemData is set.
+     * @return bool True if ItemData is set.
      */
     public function isSetItemData()
     {
@@ -114,7 +114,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsByNextTokenResult exten
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsRequest.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsRequest.php
@@ -73,7 +73,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsRequest extends FBAInbo
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -119,7 +119,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsRequest extends FBAInbo
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -165,7 +165,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsRequest extends FBAInbo
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -211,7 +211,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsRequest extends FBAInbo
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {
@@ -257,7 +257,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsRequest extends FBAInbo
     /**
      * Check to see if LastUpdatedBefore is set.
      *
-     * @return true if LastUpdatedBefore is set.
+     * @return bool True if LastUpdatedBefore is set.
      */
     public function isSetLastUpdatedBefore()
     {
@@ -303,7 +303,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsRequest extends FBAInbo
     /**
      * Check to see if LastUpdatedAfter is set.
      *
-     * @return true if LastUpdatedAfter is set.
+     * @return bool True if LastUpdatedAfter is set.
      */
     public function isSetLastUpdatedAfter()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsResponse.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsResponse extends FBAInb
     /**
      * Check to see if ListInboundShipmentItemsResult is set.
      *
-     * @return true if ListInboundShipmentItemsResult is set.
+     * @return bool True if ListInboundShipmentItemsResult is set.
      */
     public function isSetListInboundShipmentItemsResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsResponse extends FBAInb
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsResponse extends FBAInb
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsResult.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentItemsResult.php
@@ -68,7 +68,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsResult extends FBAInbou
     /**
      * Check to see if ItemData is set.
      *
-     * @return true if ItemData is set.
+     * @return bool True if ItemData is set.
      */
     public function isSetItemData()
     {
@@ -114,7 +114,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentItemsResult extends FBAInbou
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentsByNextTokenRequest.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentsByNextTokenRequest.php
@@ -69,7 +69,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsByNextTokenRequest extends 
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -115,7 +115,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsByNextTokenRequest extends 
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -161,7 +161,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsByNextTokenRequest extends 
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -207,7 +207,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsByNextTokenRequest extends 
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentsByNextTokenResponse.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentsByNextTokenResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsByNextTokenResponse extends
     /**
      * Check to see if ListInboundShipmentsByNextTokenResult is set.
      *
-     * @return true if ListInboundShipmentsByNextTokenResult is set.
+     * @return bool True if ListInboundShipmentsByNextTokenResult is set.
      */
     public function isSetListInboundShipmentsByNextTokenResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsByNextTokenResponse extends
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsByNextTokenResponse extends
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentsByNextTokenResult.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentsByNextTokenResult.php
@@ -68,7 +68,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsByNextTokenResult extends F
     /**
      * Check to see if ShipmentData is set.
      *
-     * @return true if ShipmentData is set.
+     * @return bool True if ShipmentData is set.
      */
     public function isSetShipmentData()
     {
@@ -114,7 +114,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsByNextTokenResult extends F
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentsRequest.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentsRequest.php
@@ -78,7 +78,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsRequest extends FBAInboundS
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -124,7 +124,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsRequest extends FBAInboundS
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -170,7 +170,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsRequest extends FBAInboundS
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -216,7 +216,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsRequest extends FBAInboundS
     /**
      * Check to see if ShipmentStatusList is set.
      *
-     * @return true if ShipmentStatusList is set.
+     * @return bool True if ShipmentStatusList is set.
      */
     public function isSetShipmentStatusList()
     {
@@ -262,7 +262,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsRequest extends FBAInboundS
     /**
      * Check to see if ShipmentIdList is set.
      *
-     * @return true if ShipmentIdList is set.
+     * @return bool True if ShipmentIdList is set.
      */
     public function isSetShipmentIdList()
     {
@@ -308,7 +308,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsRequest extends FBAInboundS
     /**
      * Check to see if LastUpdatedBefore is set.
      *
-     * @return true if LastUpdatedBefore is set.
+     * @return bool True if LastUpdatedBefore is set.
      */
     public function isSetLastUpdatedBefore()
     {
@@ -354,7 +354,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsRequest extends FBAInboundS
     /**
      * Check to see if LastUpdatedAfter is set.
      *
-     * @return true if LastUpdatedAfter is set.
+     * @return bool True if LastUpdatedAfter is set.
      */
     public function isSetLastUpdatedAfter()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentsResponse.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentsResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsResponse extends FBAInbound
     /**
      * Check to see if ListInboundShipmentsResult is set.
      *
-     * @return true if ListInboundShipmentsResult is set.
+     * @return bool True if ListInboundShipmentsResult is set.
      */
     public function isSetListInboundShipmentsResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsResponse extends FBAInbound
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsResponse extends FBAInbound
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/ListInboundShipmentsResult.php
+++ b/src/FBAInboundServiceMWS/Model/ListInboundShipmentsResult.php
@@ -68,7 +68,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsResult extends FBAInboundSe
     /**
      * Check to see if ShipmentData is set.
      *
-     * @return true if ShipmentData is set.
+     * @return bool True if ShipmentData is set.
      */
     public function isSetShipmentData()
     {
@@ -114,7 +114,7 @@ class FBAInboundServiceMWS_Model_ListInboundShipmentsResult extends FBAInboundSe
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/FBAInboundServiceMWS/Model/NonPartneredLtlDataInput.php
+++ b/src/FBAInboundServiceMWS/Model/NonPartneredLtlDataInput.php
@@ -65,7 +65,7 @@ class FBAInboundServiceMWS_Model_NonPartneredLtlDataInput extends FBAInboundServ
     /**
      * Check to see if CarrierName is set.
      *
-     * @return true if CarrierName is set.
+     * @return bool True if CarrierName is set.
      */
     public function isSetCarrierName()
     {
@@ -111,7 +111,7 @@ class FBAInboundServiceMWS_Model_NonPartneredLtlDataInput extends FBAInboundServ
     /**
      * Check to see if ProNumber is set.
      *
-     * @return true if ProNumber is set.
+     * @return bool True if ProNumber is set.
      */
     public function isSetProNumber()
     {

--- a/src/FBAInboundServiceMWS/Model/NonPartneredLtlDataOutput.php
+++ b/src/FBAInboundServiceMWS/Model/NonPartneredLtlDataOutput.php
@@ -65,7 +65,7 @@ class FBAInboundServiceMWS_Model_NonPartneredLtlDataOutput extends FBAInboundSer
     /**
      * Check to see if CarrierName is set.
      *
-     * @return true if CarrierName is set.
+     * @return bool True if CarrierName is set.
      */
     public function isSetCarrierName()
     {
@@ -111,7 +111,7 @@ class FBAInboundServiceMWS_Model_NonPartneredLtlDataOutput extends FBAInboundSer
     /**
      * Check to see if ProNumber is set.
      *
-     * @return true if ProNumber is set.
+     * @return bool True if ProNumber is set.
      */
     public function isSetProNumber()
     {

--- a/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelDataInput.php
+++ b/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelDataInput.php
@@ -68,7 +68,7 @@ class FBAInboundServiceMWS_Model_NonPartneredSmallParcelDataInput extends FBAInb
     /**
      * Check to see if CarrierName is set.
      *
-     * @return true if CarrierName is set.
+     * @return bool True if CarrierName is set.
      */
     public function isSetCarrierName()
     {
@@ -114,7 +114,7 @@ class FBAInboundServiceMWS_Model_NonPartneredSmallParcelDataInput extends FBAInb
     /**
      * Check to see if PackageList is set.
      *
-     * @return true if PackageList is set.
+     * @return bool True if PackageList is set.
      */
     public function isSetPackageList()
     {

--- a/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelDataOutput.php
+++ b/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelDataOutput.php
@@ -66,7 +66,7 @@ class FBAInboundServiceMWS_Model_NonPartneredSmallParcelDataOutput extends FBAIn
     /**
      * Check to see if PackageList is set.
      *
-     * @return true if PackageList is set.
+     * @return bool True if PackageList is set.
      */
     public function isSetPackageList()
     {

--- a/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelPackageInput.php
+++ b/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelPackageInput.php
@@ -63,7 +63,7 @@ class FBAInboundServiceMWS_Model_NonPartneredSmallParcelPackageInput extends FBA
     /**
      * Check to see if TrackingId is set.
      *
-     * @return true if TrackingId is set.
+     * @return bool True if TrackingId is set.
      */
     public function isSetTrackingId()
     {

--- a/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelPackageInputList.php
+++ b/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelPackageInputList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_NonPartneredSmallParcelPackageInputList extends
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelPackageOutput.php
+++ b/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelPackageOutput.php
@@ -67,7 +67,7 @@ class FBAInboundServiceMWS_Model_NonPartneredSmallParcelPackageOutput extends FB
     /**
      * Check to see if CarrierName is set.
      *
-     * @return true if CarrierName is set.
+     * @return bool True if CarrierName is set.
      */
     public function isSetCarrierName()
     {
@@ -113,7 +113,7 @@ class FBAInboundServiceMWS_Model_NonPartneredSmallParcelPackageOutput extends FB
     /**
      * Check to see if TrackingId is set.
      *
-     * @return true if TrackingId is set.
+     * @return bool True if TrackingId is set.
      */
     public function isSetTrackingId()
     {
@@ -159,7 +159,7 @@ class FBAInboundServiceMWS_Model_NonPartneredSmallParcelPackageOutput extends FB
     /**
      * Check to see if PackageStatus is set.
      *
-     * @return true if PackageStatus is set.
+     * @return bool True if PackageStatus is set.
      */
     public function isSetPackageStatus()
     {

--- a/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelPackageOutputList.php
+++ b/src/FBAInboundServiceMWS/Model/NonPartneredSmallParcelPackageOutputList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_NonPartneredSmallParcelPackageOutputList extend
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/Pallet.php
+++ b/src/FBAInboundServiceMWS/Model/Pallet.php
@@ -67,7 +67,7 @@ class FBAInboundServiceMWS_Model_Pallet extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Dimensions is set.
      *
-     * @return true if Dimensions is set.
+     * @return bool True if Dimensions is set.
      */
     public function isSetDimensions()
     {
@@ -113,7 +113,7 @@ class FBAInboundServiceMWS_Model_Pallet extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Weight is set.
      *
-     * @return true if Weight is set.
+     * @return bool True if Weight is set.
      */
     public function isSetWeight()
     {
@@ -137,7 +137,7 @@ class FBAInboundServiceMWS_Model_Pallet extends FBAInboundServiceMWS_Model
     /**
      * Check the value of IsStacked.
      *
-     * @return true if IsStacked is set to true.
+     * @return bool True if IsStacked is set to true.
      */
     public function isIsStacked()
     {
@@ -169,7 +169,7 @@ class FBAInboundServiceMWS_Model_Pallet extends FBAInboundServiceMWS_Model
     /**
      * Check to see if IsStacked is set.
      *
-     * @return true if IsStacked is set.
+     * @return bool True if IsStacked is set.
      */
     public function isSetIsStacked()
     {

--- a/src/FBAInboundServiceMWS/Model/PalletList.php
+++ b/src/FBAInboundServiceMWS/Model/PalletList.php
@@ -77,7 +77,7 @@ class FBAInboundServiceMWS_Model_PalletList extends FBAInboundServiceMWS_Model
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/PartneredEstimate.php
+++ b/src/FBAInboundServiceMWS/Model/PartneredEstimate.php
@@ -67,7 +67,7 @@ class FBAInboundServiceMWS_Model_PartneredEstimate extends FBAInboundServiceMWS_
     /**
      * Check to see if Amount is set.
      *
-     * @return true if Amount is set.
+     * @return bool True if Amount is set.
      */
     public function isSetAmount()
     {
@@ -113,7 +113,7 @@ class FBAInboundServiceMWS_Model_PartneredEstimate extends FBAInboundServiceMWS_
     /**
      * Check to see if ConfirmDeadline is set.
      *
-     * @return true if ConfirmDeadline is set.
+     * @return bool True if ConfirmDeadline is set.
      */
     public function isSetConfirmDeadline()
     {
@@ -159,7 +159,7 @@ class FBAInboundServiceMWS_Model_PartneredEstimate extends FBAInboundServiceMWS_
     /**
      * Check to see if VoidDeadline is set.
      *
-     * @return true if VoidDeadline is set.
+     * @return bool True if VoidDeadline is set.
      */
     public function isSetVoidDeadline()
     {

--- a/src/FBAInboundServiceMWS/Model/PartneredLtlDataInput.php
+++ b/src/FBAInboundServiceMWS/Model/PartneredLtlDataInput.php
@@ -75,7 +75,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataInput extends FBAInboundService
     /**
      * Check to see if Contact is set.
      *
-     * @return true if Contact is set.
+     * @return bool True if Contact is set.
      */
     public function isSetContact()
     {
@@ -121,7 +121,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataInput extends FBAInboundService
     /**
      * Check to see if BoxCount is set.
      *
-     * @return true if BoxCount is set.
+     * @return bool True if BoxCount is set.
      */
     public function isSetBoxCount()
     {
@@ -167,7 +167,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataInput extends FBAInboundService
     /**
      * Check to see if SellerFreightClass is set.
      *
-     * @return true if SellerFreightClass is set.
+     * @return bool True if SellerFreightClass is set.
      */
     public function isSetSellerFreightClass()
     {
@@ -213,7 +213,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataInput extends FBAInboundService
     /**
      * Check to see if FreightReadyDate is set.
      *
-     * @return true if FreightReadyDate is set.
+     * @return bool True if FreightReadyDate is set.
      */
     public function isSetFreightReadyDate()
     {
@@ -259,7 +259,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataInput extends FBAInboundService
     /**
      * Check to see if PalletList is set.
      *
-     * @return true if PalletList is set.
+     * @return bool True if PalletList is set.
      */
     public function isSetPalletList()
     {
@@ -305,7 +305,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataInput extends FBAInboundService
     /**
      * Check to see if TotalWeight is set.
      *
-     * @return true if TotalWeight is set.
+     * @return bool True if TotalWeight is set.
      */
     public function isSetTotalWeight()
     {
@@ -351,7 +351,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataInput extends FBAInboundService
     /**
      * Check to see if SellerDeclaredValue is set.
      *
-     * @return true if SellerDeclaredValue is set.
+     * @return bool True if SellerDeclaredValue is set.
      */
     public function isSetSellerDeclaredValue()
     {

--- a/src/FBAInboundServiceMWS/Model/PartneredLtlDataOutput.php
+++ b/src/FBAInboundServiceMWS/Model/PartneredLtlDataOutput.php
@@ -94,7 +94,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if Contact is set.
      *
-     * @return true if Contact is set.
+     * @return bool True if Contact is set.
      */
     public function isSetContact()
     {
@@ -140,7 +140,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if BoxCount is set.
      *
-     * @return true if BoxCount is set.
+     * @return bool True if BoxCount is set.
      */
     public function isSetBoxCount()
     {
@@ -186,7 +186,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if SellerFreightClass is set.
      *
-     * @return true if SellerFreightClass is set.
+     * @return bool True if SellerFreightClass is set.
      */
     public function isSetSellerFreightClass()
     {
@@ -232,7 +232,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if FreightReadyDate is set.
      *
-     * @return true if FreightReadyDate is set.
+     * @return bool True if FreightReadyDate is set.
      */
     public function isSetFreightReadyDate()
     {
@@ -278,7 +278,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if PalletList is set.
      *
-     * @return true if PalletList is set.
+     * @return bool True if PalletList is set.
      */
     public function isSetPalletList()
     {
@@ -324,7 +324,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if TotalWeight is set.
      *
-     * @return true if TotalWeight is set.
+     * @return bool True if TotalWeight is set.
      */
     public function isSetTotalWeight()
     {
@@ -370,7 +370,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if SellerDeclaredValue is set.
      *
-     * @return true if SellerDeclaredValue is set.
+     * @return bool True if SellerDeclaredValue is set.
      */
     public function isSetSellerDeclaredValue()
     {
@@ -416,7 +416,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if AmazonCalculatedValue is set.
      *
-     * @return true if AmazonCalculatedValue is set.
+     * @return bool True if AmazonCalculatedValue is set.
      */
     public function isSetAmazonCalculatedValue()
     {
@@ -462,7 +462,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if PreviewPickupDate is set.
      *
-     * @return true if PreviewPickupDate is set.
+     * @return bool True if PreviewPickupDate is set.
      */
     public function isSetPreviewPickupDate()
     {
@@ -508,7 +508,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if PreviewDeliveryDate is set.
      *
-     * @return true if PreviewDeliveryDate is set.
+     * @return bool True if PreviewDeliveryDate is set.
      */
     public function isSetPreviewDeliveryDate()
     {
@@ -554,7 +554,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if PreviewFreightClass is set.
      *
-     * @return true if PreviewFreightClass is set.
+     * @return bool True if PreviewFreightClass is set.
      */
     public function isSetPreviewFreightClass()
     {
@@ -600,7 +600,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if AmazonReferenceId is set.
      *
-     * @return true if AmazonReferenceId is set.
+     * @return bool True if AmazonReferenceId is set.
      */
     public function isSetAmazonReferenceId()
     {
@@ -624,7 +624,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check the value of IsBillOfLadingAvailable.
      *
-     * @return true if IsBillOfLadingAvailable is set to true.
+     * @return bool True if IsBillOfLadingAvailable is set to true.
      */
     public function isIsBillOfLadingAvailable()
     {
@@ -656,7 +656,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if IsBillOfLadingAvailable is set.
      *
-     * @return true if IsBillOfLadingAvailable is set.
+     * @return bool True if IsBillOfLadingAvailable is set.
      */
     public function isSetIsBillOfLadingAvailable()
     {
@@ -702,7 +702,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if PartneredEstimate is set.
      *
-     * @return true if PartneredEstimate is set.
+     * @return bool True if PartneredEstimate is set.
      */
     public function isSetPartneredEstimate()
     {
@@ -748,7 +748,7 @@ class FBAInboundServiceMWS_Model_PartneredLtlDataOutput extends FBAInboundServic
     /**
      * Check to see if CarrierName is set.
      *
-     * @return true if CarrierName is set.
+     * @return bool True if CarrierName is set.
      */
     public function isSetCarrierName()
     {

--- a/src/FBAInboundServiceMWS/Model/PartneredSmallParcelDataInput.php
+++ b/src/FBAInboundServiceMWS/Model/PartneredSmallParcelDataInput.php
@@ -66,7 +66,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelDataInput extends FBAInboun
     /**
      * Check to see if PackageList is set.
      *
-     * @return true if PackageList is set.
+     * @return bool True if PackageList is set.
      */
     public function isSetPackageList()
     {

--- a/src/FBAInboundServiceMWS/Model/PartneredSmallParcelDataOutput.php
+++ b/src/FBAInboundServiceMWS/Model/PartneredSmallParcelDataOutput.php
@@ -71,7 +71,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelDataOutput extends FBAInbou
     /**
      * Check to see if PackageList is set.
      *
-     * @return true if PackageList is set.
+     * @return bool True if PackageList is set.
      */
     public function isSetPackageList()
     {
@@ -117,7 +117,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelDataOutput extends FBAInbou
     /**
      * Check to see if PartneredEstimate is set.
      *
-     * @return true if PartneredEstimate is set.
+     * @return bool True if PartneredEstimate is set.
      */
     public function isSetPartneredEstimate()
     {

--- a/src/FBAInboundServiceMWS/Model/PartneredSmallParcelPackageInput.php
+++ b/src/FBAInboundServiceMWS/Model/PartneredSmallParcelPackageInput.php
@@ -65,7 +65,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelPackageInput extends FBAInb
     /**
      * Check to see if Dimensions is set.
      *
-     * @return true if Dimensions is set.
+     * @return bool True if Dimensions is set.
      */
     public function isSetDimensions()
     {
@@ -111,7 +111,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelPackageInput extends FBAInb
     /**
      * Check to see if Weight is set.
      *
-     * @return true if Weight is set.
+     * @return bool True if Weight is set.
      */
     public function isSetWeight()
     {

--- a/src/FBAInboundServiceMWS/Model/PartneredSmallParcelPackageInputList.php
+++ b/src/FBAInboundServiceMWS/Model/PartneredSmallParcelPackageInputList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelPackageInputList extends FB
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/PartneredSmallParcelPackageOutput.php
+++ b/src/FBAInboundServiceMWS/Model/PartneredSmallParcelPackageOutput.php
@@ -71,7 +71,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelPackageOutput extends FBAIn
     /**
      * Check to see if Dimensions is set.
      *
-     * @return true if Dimensions is set.
+     * @return bool True if Dimensions is set.
      */
     public function isSetDimensions()
     {
@@ -117,7 +117,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelPackageOutput extends FBAIn
     /**
      * Check to see if Weight is set.
      *
-     * @return true if Weight is set.
+     * @return bool True if Weight is set.
      */
     public function isSetWeight()
     {
@@ -163,7 +163,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelPackageOutput extends FBAIn
     /**
      * Check to see if CarrierName is set.
      *
-     * @return true if CarrierName is set.
+     * @return bool True if CarrierName is set.
      */
     public function isSetCarrierName()
     {
@@ -209,7 +209,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelPackageOutput extends FBAIn
     /**
      * Check to see if TrackingId is set.
      *
-     * @return true if TrackingId is set.
+     * @return bool True if TrackingId is set.
      */
     public function isSetTrackingId()
     {
@@ -255,7 +255,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelPackageOutput extends FBAIn
     /**
      * Check to see if PackageStatus is set.
      *
-     * @return true if PackageStatus is set.
+     * @return bool True if PackageStatus is set.
      */
     public function isSetPackageStatus()
     {

--- a/src/FBAInboundServiceMWS/Model/PartneredSmallParcelPackageOutputList.php
+++ b/src/FBAInboundServiceMWS/Model/PartneredSmallParcelPackageOutputList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_PartneredSmallParcelPackageOutputList extends F
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/PrepInstructionList.php
+++ b/src/FBAInboundServiceMWS/Model/PrepInstructionList.php
@@ -77,7 +77,7 @@ class FBAInboundServiceMWS_Model_PrepInstructionList extends FBAInboundServiceMW
     /**
      * Check to see if PrepInstruction is set.
      *
-     * @return true if PrepInstruction is set.
+     * @return bool True if PrepInstruction is set.
      */
     public function isSetPrepInstruction()
     {

--- a/src/FBAInboundServiceMWS/Model/PutTransportContentRequest.php
+++ b/src/FBAInboundServiceMWS/Model/PutTransportContentRequest.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_PutTransportContentRequest extends FBAInboundSe
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_PutTransportContentRequest extends FBAInboundSe
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_PutTransportContentRequest extends FBAInboundSe
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {
@@ -192,7 +192,7 @@ class FBAInboundServiceMWS_Model_PutTransportContentRequest extends FBAInboundSe
     /**
      * Check the value of IsPartnered.
      *
-     * @return true if IsPartnered is set to true.
+     * @return bool True if IsPartnered is set to true.
      */
     public function isIsPartnered()
     {
@@ -224,7 +224,7 @@ class FBAInboundServiceMWS_Model_PutTransportContentRequest extends FBAInboundSe
     /**
      * Check to see if IsPartnered is set.
      *
-     * @return true if IsPartnered is set.
+     * @return bool True if IsPartnered is set.
      */
     public function isSetIsPartnered()
     {
@@ -270,7 +270,7 @@ class FBAInboundServiceMWS_Model_PutTransportContentRequest extends FBAInboundSe
     /**
      * Check to see if ShipmentType is set.
      *
-     * @return true if ShipmentType is set.
+     * @return bool True if ShipmentType is set.
      */
     public function isSetShipmentType()
     {
@@ -316,7 +316,7 @@ class FBAInboundServiceMWS_Model_PutTransportContentRequest extends FBAInboundSe
     /**
      * Check to see if TransportDetails is set.
      *
-     * @return true if TransportDetails is set.
+     * @return bool True if TransportDetails is set.
      */
     public function isSetTransportDetails()
     {

--- a/src/FBAInboundServiceMWS/Model/PutTransportContentResponse.php
+++ b/src/FBAInboundServiceMWS/Model/PutTransportContentResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_PutTransportContentResponse extends FBAInboundS
     /**
      * Check to see if PutTransportContentResult is set.
      *
-     * @return true if PutTransportContentResult is set.
+     * @return bool True if PutTransportContentResult is set.
      */
     public function isSetPutTransportContentResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_PutTransportContentResponse extends FBAInboundS
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_PutTransportContentResponse extends FBAInboundS
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/PutTransportContentResult.php
+++ b/src/FBAInboundServiceMWS/Model/PutTransportContentResult.php
@@ -66,7 +66,7 @@ class FBAInboundServiceMWS_Model_PutTransportContentResult extends FBAInboundSer
     /**
      * Check to see if TransportResult is set.
      *
-     * @return true if TransportResult is set.
+     * @return bool True if TransportResult is set.
      */
     public function isSetTransportResult()
     {

--- a/src/FBAInboundServiceMWS/Model/ResponseMetadata.php
+++ b/src/FBAInboundServiceMWS/Model/ResponseMetadata.php
@@ -63,7 +63,7 @@ class FBAInboundServiceMWS_Model_ResponseMetadata extends FBAInboundServiceMWS_M
     /**
      * Check to see if RequestId is set.
      *
-     * @return true if RequestId is set.
+     * @return bool True if RequestId is set.
      */
     public function isSetRequestId()
     {

--- a/src/FBAInboundServiceMWS/Model/SKUPrepInstructions.php
+++ b/src/FBAInboundServiceMWS/Model/SKUPrepInstructions.php
@@ -74,7 +74,7 @@ class FBAInboundServiceMWS_Model_SKUPrepInstructions extends FBAInboundServiceMW
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -120,7 +120,7 @@ class FBAInboundServiceMWS_Model_SKUPrepInstructions extends FBAInboundServiceMW
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {
@@ -166,7 +166,7 @@ class FBAInboundServiceMWS_Model_SKUPrepInstructions extends FBAInboundServiceMW
     /**
      * Check to see if BarcodeInstruction is set.
      *
-     * @return true if BarcodeInstruction is set.
+     * @return bool True if BarcodeInstruction is set.
      */
     public function isSetBarcodeInstruction()
     {
@@ -212,7 +212,7 @@ class FBAInboundServiceMWS_Model_SKUPrepInstructions extends FBAInboundServiceMW
     /**
      * Check to see if PrepGuidance is set.
      *
-     * @return true if PrepGuidance is set.
+     * @return bool True if PrepGuidance is set.
      */
     public function isSetPrepGuidance()
     {
@@ -258,7 +258,7 @@ class FBAInboundServiceMWS_Model_SKUPrepInstructions extends FBAInboundServiceMW
     /**
      * Check to see if PrepInstructionList is set.
      *
-     * @return true if PrepInstructionList is set.
+     * @return bool True if PrepInstructionList is set.
      */
     public function isSetPrepInstructionList()
     {

--- a/src/FBAInboundServiceMWS/Model/SKUPrepInstructionsList.php
+++ b/src/FBAInboundServiceMWS/Model/SKUPrepInstructionsList.php
@@ -80,7 +80,7 @@ class FBAInboundServiceMWS_Model_SKUPrepInstructionsList extends FBAInboundServi
     /**
      * Check to see if SKUPrepInstructions is set.
      *
-     * @return true if SKUPrepInstructions is set.
+     * @return bool True if SKUPrepInstructions is set.
      */
     public function isSetSKUPrepInstructions()
     {

--- a/src/FBAInboundServiceMWS/Model/SellerSKUList.php
+++ b/src/FBAInboundServiceMWS/Model/SellerSKUList.php
@@ -77,7 +77,7 @@ class FBAInboundServiceMWS_Model_SellerSKUList extends FBAInboundServiceMWS_Mode
     /**
      * Check to see if Id is set.
      *
-     * @return true if Id is set.
+     * @return bool True if Id is set.
      */
     public function isSetId()
     {

--- a/src/FBAInboundServiceMWS/Model/ShipmentIdList.php
+++ b/src/FBAInboundServiceMWS/Model/ShipmentIdList.php
@@ -77,7 +77,7 @@ class FBAInboundServiceMWS_Model_ShipmentIdList extends FBAInboundServiceMWS_Mod
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/ShipmentStatusList.php
+++ b/src/FBAInboundServiceMWS/Model/ShipmentStatusList.php
@@ -77,7 +77,7 @@ class FBAInboundServiceMWS_Model_ShipmentStatusList extends FBAInboundServiceMWS
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInboundServiceMWS/Model/TransportContent.php
+++ b/src/FBAInboundServiceMWS/Model/TransportContent.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_TransportContent extends FBAInboundServiceMWS_M
     /**
      * Check to see if TransportHeader is set.
      *
-     * @return true if TransportHeader is set.
+     * @return bool True if TransportHeader is set.
      */
     public function isSetTransportHeader()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_TransportContent extends FBAInboundServiceMWS_M
     /**
      * Check to see if TransportDetails is set.
      *
-     * @return true if TransportDetails is set.
+     * @return bool True if TransportDetails is set.
      */
     public function isSetTransportDetails()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_TransportContent extends FBAInboundServiceMWS_M
     /**
      * Check to see if TransportResult is set.
      *
-     * @return true if TransportResult is set.
+     * @return bool True if TransportResult is set.
      */
     public function isSetTransportResult()
     {

--- a/src/FBAInboundServiceMWS/Model/TransportDetailInput.php
+++ b/src/FBAInboundServiceMWS/Model/TransportDetailInput.php
@@ -81,7 +81,7 @@ class FBAInboundServiceMWS_Model_TransportDetailInput extends FBAInboundServiceM
     /**
      * Check to see if PartneredSmallParcelData is set.
      *
-     * @return true if PartneredSmallParcelData is set.
+     * @return bool True if PartneredSmallParcelData is set.
      */
     public function isSetPartneredSmallParcelData()
     {
@@ -127,7 +127,7 @@ class FBAInboundServiceMWS_Model_TransportDetailInput extends FBAInboundServiceM
     /**
      * Check to see if NonPartneredSmallParcelData is set.
      *
-     * @return true if NonPartneredSmallParcelData is set.
+     * @return bool True if NonPartneredSmallParcelData is set.
      */
     public function isSetNonPartneredSmallParcelData()
     {
@@ -173,7 +173,7 @@ class FBAInboundServiceMWS_Model_TransportDetailInput extends FBAInboundServiceM
     /**
      * Check to see if PartneredLtlData is set.
      *
-     * @return true if PartneredLtlData is set.
+     * @return bool True if PartneredLtlData is set.
      */
     public function isSetPartneredLtlData()
     {
@@ -219,7 +219,7 @@ class FBAInboundServiceMWS_Model_TransportDetailInput extends FBAInboundServiceM
     /**
      * Check to see if NonPartneredLtlData is set.
      *
-     * @return true if NonPartneredLtlData is set.
+     * @return bool True if NonPartneredLtlData is set.
      */
     public function isSetNonPartneredLtlData()
     {

--- a/src/FBAInboundServiceMWS/Model/TransportDetailOutput.php
+++ b/src/FBAInboundServiceMWS/Model/TransportDetailOutput.php
@@ -81,7 +81,7 @@ class FBAInboundServiceMWS_Model_TransportDetailOutput extends FBAInboundService
     /**
      * Check to see if PartneredSmallParcelData is set.
      *
-     * @return true if PartneredSmallParcelData is set.
+     * @return bool True if PartneredSmallParcelData is set.
      */
     public function isSetPartneredSmallParcelData()
     {
@@ -127,7 +127,7 @@ class FBAInboundServiceMWS_Model_TransportDetailOutput extends FBAInboundService
     /**
      * Check to see if NonPartneredSmallParcelData is set.
      *
-     * @return true if NonPartneredSmallParcelData is set.
+     * @return bool True if NonPartneredSmallParcelData is set.
      */
     public function isSetNonPartneredSmallParcelData()
     {
@@ -173,7 +173,7 @@ class FBAInboundServiceMWS_Model_TransportDetailOutput extends FBAInboundService
     /**
      * Check to see if PartneredLtlData is set.
      *
-     * @return true if PartneredLtlData is set.
+     * @return bool True if PartneredLtlData is set.
      */
     public function isSetPartneredLtlData()
     {
@@ -219,7 +219,7 @@ class FBAInboundServiceMWS_Model_TransportDetailOutput extends FBAInboundService
     /**
      * Check to see if NonPartneredLtlData is set.
      *
-     * @return true if NonPartneredLtlData is set.
+     * @return bool True if NonPartneredLtlData is set.
      */
     public function isSetNonPartneredLtlData()
     {

--- a/src/FBAInboundServiceMWS/Model/TransportDocument.php
+++ b/src/FBAInboundServiceMWS/Model/TransportDocument.php
@@ -65,7 +65,7 @@ class FBAInboundServiceMWS_Model_TransportDocument extends FBAInboundServiceMWS_
     /**
      * Check to see if PdfDocument is set.
      *
-     * @return true if PdfDocument is set.
+     * @return bool True if PdfDocument is set.
      */
     public function isSetPdfDocument()
     {
@@ -111,7 +111,7 @@ class FBAInboundServiceMWS_Model_TransportDocument extends FBAInboundServiceMWS_
     /**
      * Check to see if Checksum is set.
      *
-     * @return true if Checksum is set.
+     * @return bool True if Checksum is set.
      */
     public function isSetChecksum()
     {

--- a/src/FBAInboundServiceMWS/Model/TransportHeader.php
+++ b/src/FBAInboundServiceMWS/Model/TransportHeader.php
@@ -69,7 +69,7 @@ class FBAInboundServiceMWS_Model_TransportHeader extends FBAInboundServiceMWS_Mo
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -115,7 +115,7 @@ class FBAInboundServiceMWS_Model_TransportHeader extends FBAInboundServiceMWS_Mo
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {
@@ -139,7 +139,7 @@ class FBAInboundServiceMWS_Model_TransportHeader extends FBAInboundServiceMWS_Mo
     /**
      * Check the value of IsPartnered.
      *
-     * @return true if IsPartnered is set to true.
+     * @return bool True if IsPartnered is set to true.
      */
     public function isIsPartnered()
     {
@@ -171,7 +171,7 @@ class FBAInboundServiceMWS_Model_TransportHeader extends FBAInboundServiceMWS_Mo
     /**
      * Check to see if IsPartnered is set.
      *
-     * @return true if IsPartnered is set.
+     * @return bool True if IsPartnered is set.
      */
     public function isSetIsPartnered()
     {
@@ -217,7 +217,7 @@ class FBAInboundServiceMWS_Model_TransportHeader extends FBAInboundServiceMWS_Mo
     /**
      * Check to see if ShipmentType is set.
      *
-     * @return true if ShipmentType is set.
+     * @return bool True if ShipmentType is set.
      */
     public function isSetShipmentType()
     {

--- a/src/FBAInboundServiceMWS/Model/TransportResult.php
+++ b/src/FBAInboundServiceMWS/Model/TransportResult.php
@@ -67,7 +67,7 @@ class FBAInboundServiceMWS_Model_TransportResult extends FBAInboundServiceMWS_Mo
     /**
      * Check to see if TransportStatus is set.
      *
-     * @return true if TransportStatus is set.
+     * @return bool True if TransportStatus is set.
      */
     public function isSetTransportStatus()
     {
@@ -113,7 +113,7 @@ class FBAInboundServiceMWS_Model_TransportResult extends FBAInboundServiceMWS_Mo
     /**
      * Check to see if ErrorCode is set.
      *
-     * @return true if ErrorCode is set.
+     * @return bool True if ErrorCode is set.
      */
     public function isSetErrorCode()
     {
@@ -159,7 +159,7 @@ class FBAInboundServiceMWS_Model_TransportResult extends FBAInboundServiceMWS_Mo
     /**
      * Check to see if ErrorDescription is set.
      *
-     * @return true if ErrorDescription is set.
+     * @return bool True if ErrorDescription is set.
      */
     public function isSetErrorDescription()
     {

--- a/src/FBAInboundServiceMWS/Model/UpdateInboundShipmentRequest.php
+++ b/src/FBAInboundServiceMWS/Model/UpdateInboundShipmentRequest.php
@@ -79,7 +79,7 @@ class FBAInboundServiceMWS_Model_UpdateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -125,7 +125,7 @@ class FBAInboundServiceMWS_Model_UpdateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -171,7 +171,7 @@ class FBAInboundServiceMWS_Model_UpdateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -217,7 +217,7 @@ class FBAInboundServiceMWS_Model_UpdateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {
@@ -263,7 +263,7 @@ class FBAInboundServiceMWS_Model_UpdateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if InboundShipmentHeader is set.
      *
-     * @return true if InboundShipmentHeader is set.
+     * @return bool True if InboundShipmentHeader is set.
      */
     public function isSetInboundShipmentHeader()
     {
@@ -309,7 +309,7 @@ class FBAInboundServiceMWS_Model_UpdateInboundShipmentRequest extends FBAInbound
     /**
      * Check to see if InboundShipmentItems is set.
      *
-     * @return true if InboundShipmentItems is set.
+     * @return bool True if InboundShipmentItems is set.
      */
     public function isSetInboundShipmentItems()
     {

--- a/src/FBAInboundServiceMWS/Model/UpdateInboundShipmentResponse.php
+++ b/src/FBAInboundServiceMWS/Model/UpdateInboundShipmentResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_UpdateInboundShipmentResponse extends FBAInboun
     /**
      * Check to see if UpdateInboundShipmentResult is set.
      *
-     * @return true if UpdateInboundShipmentResult is set.
+     * @return bool True if UpdateInboundShipmentResult is set.
      */
     public function isSetUpdateInboundShipmentResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_UpdateInboundShipmentResponse extends FBAInboun
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_UpdateInboundShipmentResponse extends FBAInboun
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/UpdateInboundShipmentResult.php
+++ b/src/FBAInboundServiceMWS/Model/UpdateInboundShipmentResult.php
@@ -63,7 +63,7 @@ class FBAInboundServiceMWS_Model_UpdateInboundShipmentResult extends FBAInboundS
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {

--- a/src/FBAInboundServiceMWS/Model/VoidTransportInputRequest.php
+++ b/src/FBAInboundServiceMWS/Model/VoidTransportInputRequest.php
@@ -67,7 +67,7 @@ class FBAInboundServiceMWS_Model_VoidTransportInputRequest extends FBAInboundSer
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class FBAInboundServiceMWS_Model_VoidTransportInputRequest extends FBAInboundSer
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class FBAInboundServiceMWS_Model_VoidTransportInputRequest extends FBAInboundSer
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {

--- a/src/FBAInboundServiceMWS/Model/VoidTransportRequestResponse.php
+++ b/src/FBAInboundServiceMWS/Model/VoidTransportRequestResponse.php
@@ -76,7 +76,7 @@ class FBAInboundServiceMWS_Model_VoidTransportRequestResponse extends FBAInbound
     /**
      * Check to see if VoidTransportRequestResult is set.
      *
-     * @return true if VoidTransportRequestResult is set.
+     * @return bool True if VoidTransportRequestResult is set.
      */
     public function isSetVoidTransportRequestResult()
     {
@@ -122,7 +122,7 @@ class FBAInboundServiceMWS_Model_VoidTransportRequestResponse extends FBAInbound
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInboundServiceMWS_Model_VoidTransportRequestResponse extends FBAInbound
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInboundServiceMWS/Model/VoidTransportRequestResult.php
+++ b/src/FBAInboundServiceMWS/Model/VoidTransportRequestResult.php
@@ -66,7 +66,7 @@ class FBAInboundServiceMWS_Model_VoidTransportRequestResult extends FBAInboundSe
     /**
      * Check to see if TransportResult is set.
      *
-     * @return true if TransportResult is set.
+     * @return bool True if TransportResult is set.
      */
     public function isSetTransportResult()
     {

--- a/src/FBAInboundServiceMWS/Model/Weight.php
+++ b/src/FBAInboundServiceMWS/Model/Weight.php
@@ -65,7 +65,7 @@ class FBAInboundServiceMWS_Model_Weight extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Value is set.
      *
-     * @return true if Value is set.
+     * @return bool True if Value is set.
      */
     public function isSetValue()
     {
@@ -111,7 +111,7 @@ class FBAInboundServiceMWS_Model_Weight extends FBAInboundServiceMWS_Model
     /**
      * Check to see if Unit is set.
      *
-     * @return true if Unit is set.
+     * @return bool True if Unit is set.
      */
     public function isSetUnit()
     {

--- a/src/FBAInventoryServiceMWS/Model.php
+++ b/src/FBAInventoryServiceMWS/Model.php
@@ -404,7 +404,7 @@ abstract class FBAInventoryServiceMWS_Model
      * Checks  whether passed variable is an associative array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an associative array
+     * @return bool True if passed variable is an associative array
      */
     private function _isAssociativeArray($var)
     {
@@ -415,7 +415,7 @@ abstract class FBAInventoryServiceMWS_Model
      * Checks  whether passed variable is DOMElement
      *
      * @param mixed $var
-     * @return TRUE if passed variable is DOMElement
+     * @return bool True if passed variable is DOMElement
      */
     private function _isDOMElement($var)
     {
@@ -426,7 +426,7 @@ abstract class FBAInventoryServiceMWS_Model
      * Checks  whether passed variable is numeric array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an numeric array
+     * @return bool True if passed variable is an numeric array
      */
     protected function _isNumericArray($var)
     {

--- a/src/FBAInventoryServiceMWS/Model/GetServiceStatusRequest.php
+++ b/src/FBAInventoryServiceMWS/Model/GetServiceStatusRequest.php
@@ -67,7 +67,7 @@ class FBAInventoryServiceMWS_Model_GetServiceStatusRequest extends FBAInventoryS
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class FBAInventoryServiceMWS_Model_GetServiceStatusRequest extends FBAInventoryS
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class FBAInventoryServiceMWS_Model_GetServiceStatusRequest extends FBAInventoryS
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {

--- a/src/FBAInventoryServiceMWS/Model/GetServiceStatusResponse.php
+++ b/src/FBAInventoryServiceMWS/Model/GetServiceStatusResponse.php
@@ -76,7 +76,7 @@ class FBAInventoryServiceMWS_Model_GetServiceStatusResponse extends FBAInventory
     /**
      * Check to see if GetServiceStatusResult is set.
      *
-     * @return true if GetServiceStatusResult is set.
+     * @return bool True if GetServiceStatusResult is set.
      */
     public function isSetGetServiceStatusResult()
     {
@@ -122,7 +122,7 @@ class FBAInventoryServiceMWS_Model_GetServiceStatusResponse extends FBAInventory
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInventoryServiceMWS_Model_GetServiceStatusResponse extends FBAInventory
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInventoryServiceMWS/Model/GetServiceStatusResult.php
+++ b/src/FBAInventoryServiceMWS/Model/GetServiceStatusResult.php
@@ -65,7 +65,7 @@ class FBAInventoryServiceMWS_Model_GetServiceStatusResult extends FBAInventorySe
     /**
      * Check to see if Status is set.
      *
-     * @return true if Status is set.
+     * @return bool True if Status is set.
      */
     public function isSetStatus()
     {
@@ -111,7 +111,7 @@ class FBAInventoryServiceMWS_Model_GetServiceStatusResult extends FBAInventorySe
     /**
      * Check to see if Timestamp is set.
      *
-     * @return true if Timestamp is set.
+     * @return bool True if Timestamp is set.
      */
     public function isSetTimestamp()
     {

--- a/src/FBAInventoryServiceMWS/Model/InventorySupply.php
+++ b/src/FBAInventoryServiceMWS/Model/InventorySupply.php
@@ -83,7 +83,7 @@ class FBAInventoryServiceMWS_Model_InventorySupply extends FBAInventoryServiceMW
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -129,7 +129,7 @@ class FBAInventoryServiceMWS_Model_InventorySupply extends FBAInventoryServiceMW
     /**
      * Check to see if FNSKU is set.
      *
-     * @return true if FNSKU is set.
+     * @return bool True if FNSKU is set.
      */
     public function isSetFNSKU()
     {
@@ -175,7 +175,7 @@ class FBAInventoryServiceMWS_Model_InventorySupply extends FBAInventoryServiceMW
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {
@@ -221,7 +221,7 @@ class FBAInventoryServiceMWS_Model_InventorySupply extends FBAInventoryServiceMW
     /**
      * Check to see if Condition is set.
      *
-     * @return true if Condition is set.
+     * @return bool True if Condition is set.
      */
     public function isSetCondition()
     {
@@ -267,7 +267,7 @@ class FBAInventoryServiceMWS_Model_InventorySupply extends FBAInventoryServiceMW
     /**
      * Check to see if TotalSupplyQuantity is set.
      *
-     * @return true if TotalSupplyQuantity is set.
+     * @return bool True if TotalSupplyQuantity is set.
      */
     public function isSetTotalSupplyQuantity()
     {
@@ -313,7 +313,7 @@ class FBAInventoryServiceMWS_Model_InventorySupply extends FBAInventoryServiceMW
     /**
      * Check to see if InStockSupplyQuantity is set.
      *
-     * @return true if InStockSupplyQuantity is set.
+     * @return bool True if InStockSupplyQuantity is set.
      */
     public function isSetInStockSupplyQuantity()
     {
@@ -359,7 +359,7 @@ class FBAInventoryServiceMWS_Model_InventorySupply extends FBAInventoryServiceMW
     /**
      * Check to see if EarliestAvailability is set.
      *
-     * @return true if EarliestAvailability is set.
+     * @return bool True if EarliestAvailability is set.
      */
     public function isSetEarliestAvailability()
     {
@@ -405,7 +405,7 @@ class FBAInventoryServiceMWS_Model_InventorySupply extends FBAInventoryServiceMW
     /**
      * Check to see if SupplyDetail is set.
      *
-     * @return true if SupplyDetail is set.
+     * @return bool True if SupplyDetail is set.
      */
     public function isSetSupplyDetail()
     {

--- a/src/FBAInventoryServiceMWS/Model/InventorySupplyDetail.php
+++ b/src/FBAInventoryServiceMWS/Model/InventorySupplyDetail.php
@@ -75,7 +75,7 @@ class FBAInventoryServiceMWS_Model_InventorySupplyDetail extends FBAInventorySer
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {
@@ -121,7 +121,7 @@ class FBAInventoryServiceMWS_Model_InventorySupplyDetail extends FBAInventorySer
     /**
      * Check to see if SupplyType is set.
      *
-     * @return true if SupplyType is set.
+     * @return bool True if SupplyType is set.
      */
     public function isSetSupplyType()
     {
@@ -167,7 +167,7 @@ class FBAInventoryServiceMWS_Model_InventorySupplyDetail extends FBAInventorySer
     /**
      * Check to see if EarliestAvailableToPick is set.
      *
-     * @return true if EarliestAvailableToPick is set.
+     * @return bool True if EarliestAvailableToPick is set.
      */
     public function isSetEarliestAvailableToPick()
     {
@@ -213,7 +213,7 @@ class FBAInventoryServiceMWS_Model_InventorySupplyDetail extends FBAInventorySer
     /**
      * Check to see if LatestAvailableToPick is set.
      *
-     * @return true if LatestAvailableToPick is set.
+     * @return bool True if LatestAvailableToPick is set.
      */
     public function isSetLatestAvailableToPick()
     {

--- a/src/FBAInventoryServiceMWS/Model/InventorySupplyDetailList.php
+++ b/src/FBAInventoryServiceMWS/Model/InventorySupplyDetailList.php
@@ -80,7 +80,7 @@ class FBAInventoryServiceMWS_Model_InventorySupplyDetailList extends FBAInventor
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInventoryServiceMWS/Model/InventorySupplyList.php
+++ b/src/FBAInventoryServiceMWS/Model/InventorySupplyList.php
@@ -80,7 +80,7 @@ class FBAInventoryServiceMWS_Model_InventorySupplyList extends FBAInventoryServi
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInventoryServiceMWS/Model/ListInventorySupplyByNextTokenRequest.php
+++ b/src/FBAInventoryServiceMWS/Model/ListInventorySupplyByNextTokenRequest.php
@@ -71,7 +71,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyByNextTokenRequest extends
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -117,7 +117,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyByNextTokenRequest extends
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -163,7 +163,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyByNextTokenRequest extends
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -209,7 +209,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyByNextTokenRequest extends
     /**
      * Check to see if SupplyRegion is set.
      *
-     * @return true if SupplyRegion is set.
+     * @return bool True if SupplyRegion is set.
      */
     public function isSetSupplyRegion()
     {
@@ -255,7 +255,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyByNextTokenRequest extends
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/FBAInventoryServiceMWS/Model/ListInventorySupplyByNextTokenResponse.php
+++ b/src/FBAInventoryServiceMWS/Model/ListInventorySupplyByNextTokenResponse.php
@@ -76,7 +76,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyByNextTokenResponse extend
     /**
      * Check to see if ListInventorySupplyByNextTokenResult is set.
      *
-     * @return true if ListInventorySupplyByNextTokenResult is set.
+     * @return bool True if ListInventorySupplyByNextTokenResult is set.
      */
     public function isSetListInventorySupplyByNextTokenResult()
     {
@@ -122,7 +122,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyByNextTokenResponse extend
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyByNextTokenResponse extend
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInventoryServiceMWS/Model/ListInventorySupplyByNextTokenResult.php
+++ b/src/FBAInventoryServiceMWS/Model/ListInventorySupplyByNextTokenResult.php
@@ -68,7 +68,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyByNextTokenResult extends 
     /**
      * Check to see if InventorySupplyList is set.
      *
-     * @return true if InventorySupplyList is set.
+     * @return bool True if InventorySupplyList is set.
      */
     public function isSetInventorySupplyList()
     {
@@ -114,7 +114,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyByNextTokenResult extends 
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/FBAInventoryServiceMWS/Model/ListInventorySupplyRequest.php
+++ b/src/FBAInventoryServiceMWS/Model/ListInventorySupplyRequest.php
@@ -75,7 +75,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyRequest extends FBAInvento
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -121,7 +121,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyRequest extends FBAInvento
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -167,7 +167,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyRequest extends FBAInvento
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -213,7 +213,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyRequest extends FBAInvento
     /**
      * Check to see if SupplyRegion is set.
      *
-     * @return true if SupplyRegion is set.
+     * @return bool True if SupplyRegion is set.
      */
     public function isSetSupplyRegion()
     {
@@ -259,7 +259,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyRequest extends FBAInvento
     /**
      * Check to see if SellerSkus is set.
      *
-     * @return true if SellerSkus is set.
+     * @return bool True if SellerSkus is set.
      */
     public function isSetSellerSkus()
     {
@@ -305,7 +305,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyRequest extends FBAInvento
     /**
      * Check to see if QueryStartDateTime is set.
      *
-     * @return true if QueryStartDateTime is set.
+     * @return bool True if QueryStartDateTime is set.
      */
     public function isSetQueryStartDateTime()
     {
@@ -351,7 +351,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyRequest extends FBAInvento
     /**
      * Check to see if ResponseGroup is set.
      *
-     * @return true if ResponseGroup is set.
+     * @return bool True if ResponseGroup is set.
      */
     public function isSetResponseGroup()
     {

--- a/src/FBAInventoryServiceMWS/Model/ListInventorySupplyResponse.php
+++ b/src/FBAInventoryServiceMWS/Model/ListInventorySupplyResponse.php
@@ -76,7 +76,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyResponse extends FBAInvent
     /**
      * Check to see if ListInventorySupplyResult is set.
      *
-     * @return true if ListInventorySupplyResult is set.
+     * @return bool True if ListInventorySupplyResult is set.
      */
     public function isSetListInventorySupplyResult()
     {
@@ -122,7 +122,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyResponse extends FBAInvent
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyResponse extends FBAInvent
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAInventoryServiceMWS/Model/ListInventorySupplyResult.php
+++ b/src/FBAInventoryServiceMWS/Model/ListInventorySupplyResult.php
@@ -68,7 +68,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyResult extends FBAInventor
     /**
      * Check to see if InventorySupplyList is set.
      *
-     * @return true if InventorySupplyList is set.
+     * @return bool True if InventorySupplyList is set.
      */
     public function isSetInventorySupplyList()
     {
@@ -114,7 +114,7 @@ class FBAInventoryServiceMWS_Model_ListInventorySupplyResult extends FBAInventor
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/FBAInventoryServiceMWS/Model/ResponseMetadata.php
+++ b/src/FBAInventoryServiceMWS/Model/ResponseMetadata.php
@@ -63,7 +63,7 @@ class FBAInventoryServiceMWS_Model_ResponseMetadata extends FBAInventoryServiceM
     /**
      * Check to see if RequestId is set.
      *
-     * @return true if RequestId is set.
+     * @return bool True if RequestId is set.
      */
     public function isSetRequestId()
     {

--- a/src/FBAInventoryServiceMWS/Model/SellerSkuList.php
+++ b/src/FBAInventoryServiceMWS/Model/SellerSkuList.php
@@ -77,7 +77,7 @@ class FBAInventoryServiceMWS_Model_SellerSkuList extends FBAInventoryServiceMWS_
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAInventoryServiceMWS/Model/Timepoint.php
+++ b/src/FBAInventoryServiceMWS/Model/Timepoint.php
@@ -65,7 +65,7 @@ class FBAInventoryServiceMWS_Model_Timepoint extends FBAInventoryServiceMWS_Mode
     /**
      * Check to see if TimepointType is set.
      *
-     * @return true if TimepointType is set.
+     * @return bool True if TimepointType is set.
      */
     public function isSetTimepointType()
     {
@@ -111,7 +111,7 @@ class FBAInventoryServiceMWS_Model_Timepoint extends FBAInventoryServiceMWS_Mode
     /**
      * Check to see if DateTime is set.
      *
-     * @return true if DateTime is set.
+     * @return bool True if DateTime is set.
      */
     public function isSetDateTime()
     {

--- a/src/FBAOutboundServiceMWS/Model.php
+++ b/src/FBAOutboundServiceMWS/Model.php
@@ -404,7 +404,7 @@ abstract class FBAOutboundServiceMWS_Model
      * Checks  whether passed variable is an associative array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an associative array
+     * @return bool True if passed variable is an associative array
      */
     private function _isAssociativeArray($var)
     {
@@ -415,7 +415,7 @@ abstract class FBAOutboundServiceMWS_Model
      * Checks  whether passed variable is DOMElement
      *
      * @param mixed $var
-     * @return TRUE if passed variable is DOMElement
+     * @return bool True if passed variable is DOMElement
      */
     private function _isDOMElement($var)
     {
@@ -426,7 +426,7 @@ abstract class FBAOutboundServiceMWS_Model
      * Checks  whether passed variable is numeric array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an numeric array
+     * @return bool True if passed variable is an numeric array
      */
     protected function _isNumericArray($var)
     {

--- a/src/FBAOutboundServiceMWS/Model/Address.php
+++ b/src/FBAOutboundServiceMWS/Model/Address.php
@@ -81,7 +81,7 @@ class FBAOutboundServiceMWS_Model_Address extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if Name is set.
      *
-     * @return true if Name is set.
+     * @return bool True if Name is set.
      */
     public function isSetName()
     {
@@ -127,7 +127,7 @@ class FBAOutboundServiceMWS_Model_Address extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if Line1 is set.
      *
-     * @return true if Line1 is set.
+     * @return bool True if Line1 is set.
      */
     public function isSetLine1()
     {
@@ -173,7 +173,7 @@ class FBAOutboundServiceMWS_Model_Address extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if Line2 is set.
      *
-     * @return true if Line2 is set.
+     * @return bool True if Line2 is set.
      */
     public function isSetLine2()
     {
@@ -219,7 +219,7 @@ class FBAOutboundServiceMWS_Model_Address extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if Line3 is set.
      *
-     * @return true if Line3 is set.
+     * @return bool True if Line3 is set.
      */
     public function isSetLine3()
     {
@@ -265,7 +265,7 @@ class FBAOutboundServiceMWS_Model_Address extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if DistrictOrCounty is set.
      *
-     * @return true if DistrictOrCounty is set.
+     * @return bool True if DistrictOrCounty is set.
      */
     public function isSetDistrictOrCounty()
     {
@@ -311,7 +311,7 @@ class FBAOutboundServiceMWS_Model_Address extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if City is set.
      *
-     * @return true if City is set.
+     * @return bool True if City is set.
      */
     public function isSetCity()
     {
@@ -357,7 +357,7 @@ class FBAOutboundServiceMWS_Model_Address extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if StateOrProvinceCode is set.
      *
-     * @return true if StateOrProvinceCode is set.
+     * @return bool True if StateOrProvinceCode is set.
      */
     public function isSetStateOrProvinceCode()
     {
@@ -403,7 +403,7 @@ class FBAOutboundServiceMWS_Model_Address extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if CountryCode is set.
      *
-     * @return true if CountryCode is set.
+     * @return bool True if CountryCode is set.
      */
     public function isSetCountryCode()
     {
@@ -449,7 +449,7 @@ class FBAOutboundServiceMWS_Model_Address extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if PostalCode is set.
      *
-     * @return true if PostalCode is set.
+     * @return bool True if PostalCode is set.
      */
     public function isSetPostalCode()
     {
@@ -495,7 +495,7 @@ class FBAOutboundServiceMWS_Model_Address extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if PhoneNumber is set.
      *
-     * @return true if PhoneNumber is set.
+     * @return bool True if PhoneNumber is set.
      */
     public function isSetPhoneNumber()
     {

--- a/src/FBAOutboundServiceMWS/Model/CODSettings.php
+++ b/src/FBAOutboundServiceMWS/Model/CODSettings.php
@@ -49,7 +49,7 @@ class FBAOutboundServiceMWS_Model_CODSettings extends FBAOutboundServiceMWS_Mode
     /**
      * Check the value of IsCODRequired.
      *
-     * @return true if IsCODRequired is set to true.
+     * @return bool True if IsCODRequired is set to true.
      */
     public function isIsCODRequired()
     {
@@ -81,7 +81,7 @@ class FBAOutboundServiceMWS_Model_CODSettings extends FBAOutboundServiceMWS_Mode
     /**
      * Check to see if IsCODRequired is set.
      *
-     * @return true if IsCODRequired is set.
+     * @return bool True if IsCODRequired is set.
      */
     public function isSetIsCODRequired()
     {
@@ -127,7 +127,7 @@ class FBAOutboundServiceMWS_Model_CODSettings extends FBAOutboundServiceMWS_Mode
     /**
      * Check to see if CODCharge is set.
      *
-     * @return true if CODCharge is set.
+     * @return bool True if CODCharge is set.
      */
     public function isSetCODCharge()
     {
@@ -173,7 +173,7 @@ class FBAOutboundServiceMWS_Model_CODSettings extends FBAOutboundServiceMWS_Mode
     /**
      * Check to see if CODChargeTax is set.
      *
-     * @return true if CODChargeTax is set.
+     * @return bool True if CODChargeTax is set.
      */
     public function isSetCODChargeTax()
     {
@@ -219,7 +219,7 @@ class FBAOutboundServiceMWS_Model_CODSettings extends FBAOutboundServiceMWS_Mode
     /**
      * Check to see if ShippingCharge is set.
      *
-     * @return true if ShippingCharge is set.
+     * @return bool True if ShippingCharge is set.
      */
     public function isSetShippingCharge()
     {
@@ -265,7 +265,7 @@ class FBAOutboundServiceMWS_Model_CODSettings extends FBAOutboundServiceMWS_Mode
     /**
      * Check to see if ShippingChargeTax is set.
      *
-     * @return true if ShippingChargeTax is set.
+     * @return bool True if ShippingChargeTax is set.
      */
     public function isSetShippingChargeTax()
     {

--- a/src/FBAOutboundServiceMWS/Model/CancelFulfillmentOrderRequest.php
+++ b/src/FBAOutboundServiceMWS/Model/CancelFulfillmentOrderRequest.php
@@ -69,7 +69,7 @@ class FBAOutboundServiceMWS_Model_CancelFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -115,7 +115,7 @@ class FBAOutboundServiceMWS_Model_CancelFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -161,7 +161,7 @@ class FBAOutboundServiceMWS_Model_CancelFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -207,7 +207,7 @@ class FBAOutboundServiceMWS_Model_CancelFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if SellerFulfillmentOrderId is set.
      *
-     * @return true if SellerFulfillmentOrderId is set.
+     * @return bool True if SellerFulfillmentOrderId is set.
      */
     public function isSetSellerFulfillmentOrderId()
     {

--- a/src/FBAOutboundServiceMWS/Model/CancelFulfillmentOrderResponse.php
+++ b/src/FBAOutboundServiceMWS/Model/CancelFulfillmentOrderResponse.php
@@ -71,7 +71,7 @@ class FBAOutboundServiceMWS_Model_CancelFulfillmentOrderResponse extends FBAOutb
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -117,7 +117,7 @@ class FBAOutboundServiceMWS_Model_CancelFulfillmentOrderResponse extends FBAOutb
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAOutboundServiceMWS/Model/CreateFulfillmentOrderItem.php
+++ b/src/FBAOutboundServiceMWS/Model/CreateFulfillmentOrderItem.php
@@ -84,7 +84,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -130,7 +130,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if SellerFulfillmentOrderItemId is set.
      *
-     * @return true if SellerFulfillmentOrderItemId is set.
+     * @return bool True if SellerFulfillmentOrderItemId is set.
      */
     public function isSetSellerFulfillmentOrderItemId()
     {
@@ -176,7 +176,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {
@@ -222,7 +222,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if GiftMessage is set.
      *
-     * @return true if GiftMessage is set.
+     * @return bool True if GiftMessage is set.
      */
     public function isSetGiftMessage()
     {
@@ -268,7 +268,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if DisplayableComment is set.
      *
-     * @return true if DisplayableComment is set.
+     * @return bool True if DisplayableComment is set.
      */
     public function isSetDisplayableComment()
     {
@@ -314,7 +314,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if FulfillmentNetworkSKU is set.
      *
-     * @return true if FulfillmentNetworkSKU is set.
+     * @return bool True if FulfillmentNetworkSKU is set.
      */
     public function isSetFulfillmentNetworkSKU()
     {
@@ -360,7 +360,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if OrderItemDisposition is set.
      *
-     * @return true if OrderItemDisposition is set.
+     * @return bool True if OrderItemDisposition is set.
      */
     public function isSetOrderItemDisposition()
     {
@@ -406,7 +406,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if PerUnitDeclaredValue is set.
      *
-     * @return true if PerUnitDeclaredValue is set.
+     * @return bool True if PerUnitDeclaredValue is set.
      */
     public function isSetPerUnitDeclaredValue()
     {
@@ -452,7 +452,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if PerUnitPrice is set.
      *
-     * @return true if PerUnitPrice is set.
+     * @return bool True if PerUnitPrice is set.
      */
     public function isSetPerUnitPrice()
     {
@@ -498,7 +498,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if PerUnitTax is set.
      *
-     * @return true if PerUnitTax is set.
+     * @return bool True if PerUnitTax is set.
      */
     public function isSetPerUnitTax()
     {

--- a/src/FBAOutboundServiceMWS/Model/CreateFulfillmentOrderItemList.php
+++ b/src/FBAOutboundServiceMWS/Model/CreateFulfillmentOrderItemList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderItemList extends FBAOutb
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/CreateFulfillmentOrderRequest.php
+++ b/src/FBAOutboundServiceMWS/Model/CreateFulfillmentOrderRequest.php
@@ -104,7 +104,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -150,7 +150,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -196,7 +196,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -242,7 +242,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if SellerFulfillmentOrderId is set.
      *
-     * @return true if SellerFulfillmentOrderId is set.
+     * @return bool True if SellerFulfillmentOrderId is set.
      */
     public function isSetSellerFulfillmentOrderId()
     {
@@ -288,7 +288,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if DisplayableOrderId is set.
      *
-     * @return true if DisplayableOrderId is set.
+     * @return bool True if DisplayableOrderId is set.
      */
     public function isSetDisplayableOrderId()
     {
@@ -334,7 +334,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if DisplayableOrderDateTime is set.
      *
-     * @return true if DisplayableOrderDateTime is set.
+     * @return bool True if DisplayableOrderDateTime is set.
      */
     public function isSetDisplayableOrderDateTime()
     {
@@ -380,7 +380,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if DisplayableOrderComment is set.
      *
-     * @return true if DisplayableOrderComment is set.
+     * @return bool True if DisplayableOrderComment is set.
      */
     public function isSetDisplayableOrderComment()
     {
@@ -426,7 +426,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if ShippingSpeedCategory is set.
      *
-     * @return true if ShippingSpeedCategory is set.
+     * @return bool True if ShippingSpeedCategory is set.
      */
     public function isSetShippingSpeedCategory()
     {
@@ -472,7 +472,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if DeliveryWindow is set.
      *
-     * @return true if DeliveryWindow is set.
+     * @return bool True if DeliveryWindow is set.
      */
     public function isSetDeliveryWindow()
     {
@@ -518,7 +518,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if DestinationAddress is set.
      *
-     * @return true if DestinationAddress is set.
+     * @return bool True if DestinationAddress is set.
      */
     public function isSetDestinationAddress()
     {
@@ -564,7 +564,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if FulfillmentAction is set.
      *
-     * @return true if FulfillmentAction is set.
+     * @return bool True if FulfillmentAction is set.
      */
     public function isSetFulfillmentAction()
     {
@@ -610,7 +610,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if FulfillmentPolicy is set.
      *
-     * @return true if FulfillmentPolicy is set.
+     * @return bool True if FulfillmentPolicy is set.
      */
     public function isSetFulfillmentPolicy()
     {
@@ -656,7 +656,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if FulfillmentMethod is set.
      *
-     * @return true if FulfillmentMethod is set.
+     * @return bool True if FulfillmentMethod is set.
      */
     public function isSetFulfillmentMethod()
     {
@@ -702,7 +702,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if CODSettings is set.
      *
-     * @return true if CODSettings is set.
+     * @return bool True if CODSettings is set.
      */
     public function isSetCODSettings()
     {
@@ -748,7 +748,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if ShipFromCountryCode is set.
      *
-     * @return true if ShipFromCountryCode is set.
+     * @return bool True if ShipFromCountryCode is set.
      */
     public function isSetShipFromCountryCode()
     {
@@ -794,7 +794,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if NotificationEmailList is set.
      *
-     * @return true if NotificationEmailList is set.
+     * @return bool True if NotificationEmailList is set.
      */
     public function isSetNotificationEmailList()
     {
@@ -840,7 +840,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if Items is set.
      *
-     * @return true if Items is set.
+     * @return bool True if Items is set.
      */
     public function isSetItems()
     {

--- a/src/FBAOutboundServiceMWS/Model/CreateFulfillmentOrderResponse.php
+++ b/src/FBAOutboundServiceMWS/Model/CreateFulfillmentOrderResponse.php
@@ -71,7 +71,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderResponse extends FBAOutb
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -117,7 +117,7 @@ class FBAOutboundServiceMWS_Model_CreateFulfillmentOrderResponse extends FBAOutb
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAOutboundServiceMWS/Model/Currency.php
+++ b/src/FBAOutboundServiceMWS/Model/Currency.php
@@ -65,7 +65,7 @@ class FBAOutboundServiceMWS_Model_Currency extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if CurrencyCode is set.
      *
-     * @return true if CurrencyCode is set.
+     * @return bool True if CurrencyCode is set.
      */
     public function isSetCurrencyCode()
     {
@@ -111,7 +111,7 @@ class FBAOutboundServiceMWS_Model_Currency extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if Value is set.
      *
-     * @return true if Value is set.
+     * @return bool True if Value is set.
      */
     public function isSetValue()
     {

--- a/src/FBAOutboundServiceMWS/Model/DeliveryWindow.php
+++ b/src/FBAOutboundServiceMWS/Model/DeliveryWindow.php
@@ -65,7 +65,7 @@ class FBAOutboundServiceMWS_Model_DeliveryWindow extends FBAOutboundServiceMWS_M
     /**
      * Check to see if StartDateTime is set.
      *
-     * @return true if StartDateTime is set.
+     * @return bool True if StartDateTime is set.
      */
     public function isSetStartDateTime()
     {
@@ -110,7 +110,7 @@ class FBAOutboundServiceMWS_Model_DeliveryWindow extends FBAOutboundServiceMWS_M
     /**
      * Check to see if EndDateTime is set.
      *
-     * @return true if EndDateTime is set.
+     * @return bool True if EndDateTime is set.
      */
     public function isSetEndDateTime()
     {

--- a/src/FBAOutboundServiceMWS/Model/DeliveryWindowList.php
+++ b/src/FBAOutboundServiceMWS/Model/DeliveryWindowList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_DeliveryWindowList extends FBAOutboundServiceM
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/Fee.php
+++ b/src/FBAOutboundServiceMWS/Model/Fee.php
@@ -65,7 +65,7 @@ class FBAOutboundServiceMWS_Model_Fee extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if Name is set.
      *
-     * @return true if Name is set.
+     * @return bool True if Name is set.
      */
     public function isSetName()
     {
@@ -111,7 +111,7 @@ class FBAOutboundServiceMWS_Model_Fee extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if Amount is set.
      *
-     * @return true if Amount is set.
+     * @return bool True if Amount is set.
      */
     public function isSetAmount()
     {

--- a/src/FBAOutboundServiceMWS/Model/FeeList.php
+++ b/src/FBAOutboundServiceMWS/Model/FeeList.php
@@ -77,7 +77,7 @@ class FBAOutboundServiceMWS_Model_FeeList extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentMethodList.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentMethodList.php
@@ -77,7 +77,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentMethodList extends FBAOutboundServi
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentOrder.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentOrder.php
@@ -95,7 +95,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if SellerFulfillmentOrderId is set.
      *
-     * @return true if SellerFulfillmentOrderId is set.
+     * @return bool True if SellerFulfillmentOrderId is set.
      */
     public function isSetSellerFulfillmentOrderId()
     {
@@ -141,7 +141,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if DisplayableOrderId is set.
      *
-     * @return true if DisplayableOrderId is set.
+     * @return bool True if DisplayableOrderId is set.
      */
     public function isSetDisplayableOrderId()
     {
@@ -187,7 +187,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if DisplayableOrderDateTime is set.
      *
-     * @return true if DisplayableOrderDateTime is set.
+     * @return bool True if DisplayableOrderDateTime is set.
      */
     public function isSetDisplayableOrderDateTime()
     {
@@ -233,7 +233,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if DisplayableOrderComment is set.
      *
-     * @return true if DisplayableOrderComment is set.
+     * @return bool True if DisplayableOrderComment is set.
      */
     public function isSetDisplayableOrderComment()
     {
@@ -279,7 +279,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if ShippingSpeedCategory is set.
      *
-     * @return true if ShippingSpeedCategory is set.
+     * @return bool True if ShippingSpeedCategory is set.
      */
     public function isSetShippingSpeedCategory()
     {
@@ -325,7 +325,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if DeliveryWindow is set.
      *
-     * @return true if DeliveryWindow is set.
+     * @return bool True if DeliveryWindow is set.
      */
     public function isSetDeliveryWindow()
     {
@@ -371,7 +371,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if DestinationAddress is set.
      *
-     * @return true if DestinationAddress is set.
+     * @return bool True if DestinationAddress is set.
      */
     public function isSetDestinationAddress()
     {
@@ -417,7 +417,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if FulfillmentPolicy is set.
      *
-     * @return true if FulfillmentPolicy is set.
+     * @return bool True if FulfillmentPolicy is set.
      */
     public function isSetFulfillmentPolicy()
     {
@@ -463,7 +463,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if FulfillmentMethod is set.
      *
-     * @return true if FulfillmentMethod is set.
+     * @return bool True if FulfillmentMethod is set.
      */
     public function isSetFulfillmentMethod()
     {
@@ -509,7 +509,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if CODSettings is set.
      *
-     * @return true if CODSettings is set.
+     * @return bool True if CODSettings is set.
      */
     public function isSetCODSettings()
     {
@@ -555,7 +555,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if ReceivedDateTime is set.
      *
-     * @return true if ReceivedDateTime is set.
+     * @return bool True if ReceivedDateTime is set.
      */
     public function isSetReceivedDateTime()
     {
@@ -601,7 +601,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if FulfillmentOrderStatus is set.
      *
-     * @return true if FulfillmentOrderStatus is set.
+     * @return bool True if FulfillmentOrderStatus is set.
      */
     public function isSetFulfillmentOrderStatus()
     {
@@ -647,7 +647,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if StatusUpdatedDateTime is set.
      *
-     * @return true if StatusUpdatedDateTime is set.
+     * @return bool True if StatusUpdatedDateTime is set.
      */
     public function isSetStatusUpdatedDateTime()
     {
@@ -693,7 +693,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrder extends FBAOutboundServiceMWS
     /**
      * Check to see if NotificationEmailList is set.
      *
-     * @return true if NotificationEmailList is set.
+     * @return bool True if NotificationEmailList is set.
      */
     public function isSetNotificationEmailList()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentOrderItem.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentOrderItem.php
@@ -92,7 +92,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -138,7 +138,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if SellerFulfillmentOrderItemId is set.
      *
-     * @return true if SellerFulfillmentOrderItemId is set.
+     * @return bool True if SellerFulfillmentOrderItemId is set.
      */
     public function isSetSellerFulfillmentOrderItemId()
     {
@@ -184,7 +184,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {
@@ -230,7 +230,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if GiftMessage is set.
      *
-     * @return true if GiftMessage is set.
+     * @return bool True if GiftMessage is set.
      */
     public function isSetGiftMessage()
     {
@@ -276,7 +276,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if DisplayableComment is set.
      *
-     * @return true if DisplayableComment is set.
+     * @return bool True if DisplayableComment is set.
      */
     public function isSetDisplayableComment()
     {
@@ -322,7 +322,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if FulfillmentNetworkSKU is set.
      *
-     * @return true if FulfillmentNetworkSKU is set.
+     * @return bool True if FulfillmentNetworkSKU is set.
      */
     public function isSetFulfillmentNetworkSKU()
     {
@@ -368,7 +368,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if OrderItemDisposition is set.
      *
-     * @return true if OrderItemDisposition is set.
+     * @return bool True if OrderItemDisposition is set.
      */
     public function isSetOrderItemDisposition()
     {
@@ -414,7 +414,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if CancelledQuantity is set.
      *
-     * @return true if CancelledQuantity is set.
+     * @return bool True if CancelledQuantity is set.
      */
     public function isSetCancelledQuantity()
     {
@@ -460,7 +460,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if UnfulfillableQuantity is set.
      *
-     * @return true if UnfulfillableQuantity is set.
+     * @return bool True if UnfulfillableQuantity is set.
      */
     public function isSetUnfulfillableQuantity()
     {
@@ -506,7 +506,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if EstimatedShipDateTime is set.
      *
-     * @return true if EstimatedShipDateTime is set.
+     * @return bool True if EstimatedShipDateTime is set.
      */
     public function isSetEstimatedShipDateTime()
     {
@@ -552,7 +552,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if EstimatedArrivalDateTime is set.
      *
-     * @return true if EstimatedArrivalDateTime is set.
+     * @return bool True if EstimatedArrivalDateTime is set.
      */
     public function isSetEstimatedArrivalDateTime()
     {
@@ -598,7 +598,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if PerUnitPrice is set.
      *
-     * @return true if PerUnitPrice is set.
+     * @return bool True if PerUnitPrice is set.
      */
     public function isSetPerUnitPrice()
     {
@@ -644,7 +644,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if PerUnitTax is set.
      *
-     * @return true if PerUnitTax is set.
+     * @return bool True if PerUnitTax is set.
      */
     public function isSetPerUnitTax()
     {
@@ -690,7 +690,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItem extends FBAOutboundServic
     /**
      * Check to see if PerUnitDeclaredValue is set.
      *
-     * @return true if PerUnitDeclaredValue is set.
+     * @return bool True if PerUnitDeclaredValue is set.
      */
     public function isSetPerUnitDeclaredValue()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentOrderItemList.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentOrderItemList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderItemList extends FBAOutboundSe
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentOrderList.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentOrderList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentOrderList extends FBAOutboundServic
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentPreview.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentPreview.php
@@ -94,7 +94,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreview extends FBAOutboundServiceM
     /**
      * Check to see if ShippingSpeedCategory is set.
      *
-     * @return true if ShippingSpeedCategory is set.
+     * @return bool True if ShippingSpeedCategory is set.
      */
     public function isSetShippingSpeedCategory()
     {
@@ -140,7 +140,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreview extends FBAOutboundServiceM
     /**
      * Check to see if ScheduledDeliveryInfo is set.
      *
-     * @return true if ScheduledDeliveryInfo is set.
+     * @return bool True if ScheduledDeliveryInfo is set.
      */
     public function isSetScheduledDeliveryInfo()
     {
@@ -164,7 +164,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreview extends FBAOutboundServiceM
     /**
      * Check the value of IsFulfillable.
      *
-     * @return true if IsFulfillable is set to true.
+     * @return bool True if IsFulfillable is set to true.
      */
     public function isIsFulfillable()
     {
@@ -196,7 +196,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreview extends FBAOutboundServiceM
     /**
      * Check to see if IsFulfillable is set.
      *
-     * @return true if IsFulfillable is set.
+     * @return bool True if IsFulfillable is set.
      */
     public function isSetIsFulfillable()
     {
@@ -220,7 +220,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreview extends FBAOutboundServiceM
     /**
      * Check the value of IsCODCapable.
      *
-     * @return true if IsCODCapable is set to true.
+     * @return bool True if IsCODCapable is set to true.
      */
     public function isIsCODCapable()
     {
@@ -252,7 +252,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreview extends FBAOutboundServiceM
     /**
      * Check to see if IsCODCapable is set.
      *
-     * @return true if IsCODCapable is set.
+     * @return bool True if IsCODCapable is set.
      */
     public function isSetIsCODCapable()
     {
@@ -298,7 +298,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreview extends FBAOutboundServiceM
     /**
      * Check to see if EstimatedShippingWeight is set.
      *
-     * @return true if EstimatedShippingWeight is set.
+     * @return bool True if EstimatedShippingWeight is set.
      */
     public function isSetEstimatedShippingWeight()
     {
@@ -344,7 +344,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreview extends FBAOutboundServiceM
     /**
      * Check to see if EstimatedFees is set.
      *
-     * @return true if EstimatedFees is set.
+     * @return bool True if EstimatedFees is set.
      */
     public function isSetEstimatedFees()
     {
@@ -390,7 +390,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreview extends FBAOutboundServiceM
     /**
      * Check to see if FulfillmentPreviewShipments is set.
      *
-     * @return true if FulfillmentPreviewShipments is set.
+     * @return bool True if FulfillmentPreviewShipments is set.
      */
     public function isSetFulfillmentPreviewShipments()
     {
@@ -436,7 +436,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreview extends FBAOutboundServiceM
     /**
      * Check to see if UnfulfillablePreviewItems is set.
      *
-     * @return true if UnfulfillablePreviewItems is set.
+     * @return bool True if UnfulfillablePreviewItems is set.
      */
     public function isSetUnfulfillablePreviewItems()
     {
@@ -482,7 +482,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreview extends FBAOutboundServiceM
     /**
      * Check to see if OrderUnfulfillableReasons is set.
      *
-     * @return true if OrderUnfulfillableReasons is set.
+     * @return bool True if OrderUnfulfillableReasons is set.
      */
     public function isSetOrderUnfulfillableReasons()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentPreviewItem.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentPreviewItem.php
@@ -74,7 +74,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewItem extends FBAOutboundServ
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -120,7 +120,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewItem extends FBAOutboundServ
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {
@@ -166,7 +166,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewItem extends FBAOutboundServ
     /**
      * Check to see if SellerFulfillmentOrderItemId is set.
      *
-     * @return true if SellerFulfillmentOrderItemId is set.
+     * @return bool True if SellerFulfillmentOrderItemId is set.
      */
     public function isSetSellerFulfillmentOrderItemId()
     {
@@ -212,7 +212,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewItem extends FBAOutboundServ
     /**
      * Check to see if EstimatedShippingWeight is set.
      *
-     * @return true if EstimatedShippingWeight is set.
+     * @return bool True if EstimatedShippingWeight is set.
      */
     public function isSetEstimatedShippingWeight()
     {
@@ -258,7 +258,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewItem extends FBAOutboundServ
     /**
      * Check to see if ShippingWeightCalculationMethod is set.
      *
-     * @return true if ShippingWeightCalculationMethod is set.
+     * @return bool True if ShippingWeightCalculationMethod is set.
      */
     public function isSetShippingWeightCalculationMethod()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentPreviewItemList.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentPreviewItemList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewItemList extends FBAOutbound
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentPreviewList.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentPreviewList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewList extends FBAOutboundServ
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentPreviewShipment.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentPreviewShipment.php
@@ -74,7 +74,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewShipment extends FBAOutbound
     /**
      * Check to see if EarliestShipDate is set.
      *
-     * @return true if EarliestShipDate is set.
+     * @return bool True if EarliestShipDate is set.
      */
     public function isSetEarliestShipDate()
     {
@@ -120,7 +120,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewShipment extends FBAOutbound
     /**
      * Check to see if LatestShipDate is set.
      *
-     * @return true if LatestShipDate is set.
+     * @return bool True if LatestShipDate is set.
      */
     public function isSetLatestShipDate()
     {
@@ -166,7 +166,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewShipment extends FBAOutbound
     /**
      * Check to see if EarliestArrivalDate is set.
      *
-     * @return true if EarliestArrivalDate is set.
+     * @return bool True if EarliestArrivalDate is set.
      */
     public function isSetEarliestArrivalDate()
     {
@@ -212,7 +212,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewShipment extends FBAOutbound
     /**
      * Check to see if LatestArrivalDate is set.
      *
-     * @return true if LatestArrivalDate is set.
+     * @return bool True if LatestArrivalDate is set.
      */
     public function isSetLatestArrivalDate()
     {
@@ -258,7 +258,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewShipment extends FBAOutbound
     /**
      * Check to see if FulfillmentPreviewItems is set.
      *
-     * @return true if FulfillmentPreviewItems is set.
+     * @return bool True if FulfillmentPreviewItems is set.
      */
     public function isSetFulfillmentPreviewItems()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentPreviewShipmentList.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentPreviewShipmentList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentPreviewShipmentList extends FBAOutb
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentShipment.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentShipment.php
@@ -81,7 +81,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipment extends FBAOutboundService
     /**
      * Check to see if AmazonShipmentId is set.
      *
-     * @return true if AmazonShipmentId is set.
+     * @return bool True if AmazonShipmentId is set.
      */
     public function isSetAmazonShipmentId()
     {
@@ -127,7 +127,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipment extends FBAOutboundService
     /**
      * Check to see if FulfillmentCenterId is set.
      *
-     * @return true if FulfillmentCenterId is set.
+     * @return bool True if FulfillmentCenterId is set.
      */
     public function isSetFulfillmentCenterId()
     {
@@ -173,7 +173,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipment extends FBAOutboundService
     /**
      * Check to see if FulfillmentShipmentStatus is set.
      *
-     * @return true if FulfillmentShipmentStatus is set.
+     * @return bool True if FulfillmentShipmentStatus is set.
      */
     public function isSetFulfillmentShipmentStatus()
     {
@@ -219,7 +219,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipment extends FBAOutboundService
     /**
      * Check to see if ShippingDateTime is set.
      *
-     * @return true if ShippingDateTime is set.
+     * @return bool True if ShippingDateTime is set.
      */
     public function isSetShippingDateTime()
     {
@@ -265,7 +265,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipment extends FBAOutboundService
     /**
      * Check to see if EstimatedArrivalDateTime is set.
      *
-     * @return true if EstimatedArrivalDateTime is set.
+     * @return bool True if EstimatedArrivalDateTime is set.
      */
     public function isSetEstimatedArrivalDateTime()
     {
@@ -311,7 +311,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipment extends FBAOutboundService
     /**
      * Check to see if FulfillmentShipmentItem is set.
      *
-     * @return true if FulfillmentShipmentItem is set.
+     * @return bool True if FulfillmentShipmentItem is set.
      */
     public function isSetFulfillmentShipmentItem()
     {
@@ -357,7 +357,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipment extends FBAOutboundService
     /**
      * Check to see if FulfillmentShipmentPackage is set.
      *
-     * @return true if FulfillmentShipmentPackage is set.
+     * @return bool True if FulfillmentShipmentPackage is set.
      */
     public function isSetFulfillmentShipmentPackage()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentShipmentItem.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentShipmentItem.php
@@ -69,7 +69,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipmentItem extends FBAOutboundSer
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -115,7 +115,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipmentItem extends FBAOutboundSer
     /**
      * Check to see if SellerFulfillmentOrderItemId is set.
      *
-     * @return true if SellerFulfillmentOrderItemId is set.
+     * @return bool True if SellerFulfillmentOrderItemId is set.
      */
     public function isSetSellerFulfillmentOrderItemId()
     {
@@ -161,7 +161,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipmentItem extends FBAOutboundSer
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {
@@ -207,7 +207,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipmentItem extends FBAOutboundSer
     /**
      * Check to see if PackageNumber is set.
      *
-     * @return true if PackageNumber is set.
+     * @return bool True if PackageNumber is set.
      */
     public function isSetPackageNumber()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentShipmentItemList.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentShipmentItemList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipmentItemList extends FBAOutboun
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentShipmentList.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentShipmentList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipmentList extends FBAOutboundSer
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentShipmentPackage.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentShipmentPackage.php
@@ -69,7 +69,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipmentPackage extends FBAOutbound
     /**
      * Check to see if PackageNumber is set.
      *
-     * @return true if PackageNumber is set.
+     * @return bool True if PackageNumber is set.
      */
     public function isSetPackageNumber()
     {
@@ -115,7 +115,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipmentPackage extends FBAOutbound
     /**
      * Check to see if CarrierCode is set.
      *
-     * @return true if CarrierCode is set.
+     * @return bool True if CarrierCode is set.
      */
     public function isSetCarrierCode()
     {
@@ -161,7 +161,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipmentPackage extends FBAOutbound
     /**
      * Check to see if TrackingNumber is set.
      *
-     * @return true if TrackingNumber is set.
+     * @return bool True if TrackingNumber is set.
      */
     public function isSetTrackingNumber()
     {
@@ -207,7 +207,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipmentPackage extends FBAOutbound
     /**
      * Check to see if EstimatedArrivalDateTime is set.
      *
-     * @return true if EstimatedArrivalDateTime is set.
+     * @return bool True if EstimatedArrivalDateTime is set.
      */
     public function isSetEstimatedArrivalDateTime()
     {

--- a/src/FBAOutboundServiceMWS/Model/FulfillmentShipmentPackageList.php
+++ b/src/FBAOutboundServiceMWS/Model/FulfillmentShipmentPackageList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_FulfillmentShipmentPackageList extends FBAOutb
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetFulfillmentOrderRequest.php
+++ b/src/FBAOutboundServiceMWS/Model/GetFulfillmentOrderRequest.php
@@ -69,7 +69,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentOrderRequest extends FBAOutbound
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -115,7 +115,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentOrderRequest extends FBAOutbound
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -161,7 +161,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentOrderRequest extends FBAOutbound
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -207,7 +207,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentOrderRequest extends FBAOutbound
     /**
      * Check to see if SellerFulfillmentOrderId is set.
      *
-     * @return true if SellerFulfillmentOrderId is set.
+     * @return bool True if SellerFulfillmentOrderId is set.
      */
     public function isSetSellerFulfillmentOrderId()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetFulfillmentOrderResponse.php
+++ b/src/FBAOutboundServiceMWS/Model/GetFulfillmentOrderResponse.php
@@ -76,7 +76,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentOrderResponse extends FBAOutboun
     /**
      * Check to see if GetFulfillmentOrderResult is set.
      *
-     * @return true if GetFulfillmentOrderResult is set.
+     * @return bool True if GetFulfillmentOrderResult is set.
      */
     public function isSetGetFulfillmentOrderResult()
     {
@@ -122,7 +122,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentOrderResponse extends FBAOutboun
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentOrderResponse extends FBAOutboun
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetFulfillmentOrderResult.php
+++ b/src/FBAOutboundServiceMWS/Model/GetFulfillmentOrderResult.php
@@ -76,7 +76,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentOrderResult extends FBAOutboundS
     /**
      * Check to see if FulfillmentOrder is set.
      *
-     * @return true if FulfillmentOrder is set.
+     * @return bool True if FulfillmentOrder is set.
      */
     public function isSetFulfillmentOrder()
     {
@@ -122,7 +122,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentOrderResult extends FBAOutboundS
     /**
      * Check to see if FulfillmentOrderItem is set.
      *
-     * @return true if FulfillmentOrderItem is set.
+     * @return bool True if FulfillmentOrderItem is set.
      */
     public function isSetFulfillmentOrderItem()
     {
@@ -168,7 +168,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentOrderResult extends FBAOutboundS
     /**
      * Check to see if FulfillmentShipment is set.
      *
-     * @return true if FulfillmentShipment is set.
+     * @return bool True if FulfillmentShipment is set.
      */
     public function isSetFulfillmentShipment()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetFulfillmentPreviewItem.php
+++ b/src/FBAOutboundServiceMWS/Model/GetFulfillmentPreviewItem.php
@@ -67,7 +67,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewItem extends FBAOutboundS
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -113,7 +113,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewItem extends FBAOutboundS
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {
@@ -159,7 +159,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewItem extends FBAOutboundS
     /**
      * Check to see if SellerFulfillmentOrderItemId is set.
      *
-     * @return true if SellerFulfillmentOrderItemId is set.
+     * @return bool True if SellerFulfillmentOrderItemId is set.
      */
     public function isSetSellerFulfillmentOrderItemId()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetFulfillmentPreviewItemList.php
+++ b/src/FBAOutboundServiceMWS/Model/GetFulfillmentPreviewItemList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewItemList extends FBAOutbo
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetFulfillmentPreviewRequest.php
+++ b/src/FBAOutboundServiceMWS/Model/GetFulfillmentPreviewRequest.php
@@ -83,7 +83,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewRequest extends FBAOutbou
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -129,7 +129,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewRequest extends FBAOutbou
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -175,7 +175,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewRequest extends FBAOutbou
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -221,7 +221,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewRequest extends FBAOutbou
     /**
      * Check to see if Address is set.
      *
-     * @return true if Address is set.
+     * @return bool True if Address is set.
      */
     public function isSetAddress()
     {
@@ -267,7 +267,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewRequest extends FBAOutbou
     /**
      * Check to see if Items is set.
      *
-     * @return true if Items is set.
+     * @return bool True if Items is set.
      */
     public function isSetItems()
     {
@@ -313,7 +313,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewRequest extends FBAOutbou
     /**
      * Check to see if ShippingSpeedCategories is set.
      *
-     * @return true if ShippingSpeedCategories is set.
+     * @return bool True if ShippingSpeedCategories is set.
      */
     public function isSetShippingSpeedCategories()
     {
@@ -337,7 +337,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewRequest extends FBAOutbou
     /**
      * Check the value of IncludeCODFulfillmentPreview.
      *
-     * @return true if IncludeCODFulfillmentPreview is set to true.
+     * @return bool True if IncludeCODFulfillmentPreview is set to true.
      */
     public function isIncludeCODFulfillmentPreview()
     {
@@ -369,7 +369,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewRequest extends FBAOutbou
     /**
      * Check to see if IncludeCODFulfillmentPreview is set.
      *
-     * @return true if IncludeCODFulfillmentPreview is set.
+     * @return bool True if IncludeCODFulfillmentPreview is set.
      */
     public function isSetIncludeCODFulfillmentPreview()
     {
@@ -393,7 +393,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewRequest extends FBAOutbou
     /**
      * Check the value of IncludeDeliveryWindows.
      *
-     * @return true if IncludeDeliveryWindows is set to true.
+     * @return bool True if IncludeDeliveryWindows is set to true.
      */
     public function isIncludeDeliveryWindows()
     {
@@ -425,7 +425,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewRequest extends FBAOutbou
     /**
      * Check to see if IncludeDeliveryWindows is set.
      *
-     * @return true if IncludeDeliveryWindows is set.
+     * @return bool True if IncludeDeliveryWindows is set.
      */
     public function isSetIncludeDeliveryWindows()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetFulfillmentPreviewResponse.php
+++ b/src/FBAOutboundServiceMWS/Model/GetFulfillmentPreviewResponse.php
@@ -76,7 +76,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewResponse extends FBAOutbo
     /**
      * Check to see if GetFulfillmentPreviewResult is set.
      *
-     * @return true if GetFulfillmentPreviewResult is set.
+     * @return bool True if GetFulfillmentPreviewResult is set.
      */
     public function isSetGetFulfillmentPreviewResult()
     {
@@ -122,7 +122,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewResponse extends FBAOutbo
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewResponse extends FBAOutbo
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetFulfillmentPreviewResult.php
+++ b/src/FBAOutboundServiceMWS/Model/GetFulfillmentPreviewResult.php
@@ -66,7 +66,7 @@ class FBAOutboundServiceMWS_Model_GetFulfillmentPreviewResult extends FBAOutboun
     /**
      * Check to see if FulfillmentPreviews is set.
      *
-     * @return true if FulfillmentPreviews is set.
+     * @return bool True if FulfillmentPreviews is set.
      */
     public function isSetFulfillmentPreviews()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetPackageTrackingDetailsRequest.php
+++ b/src/FBAOutboundServiceMWS/Model/GetPackageTrackingDetailsRequest.php
@@ -67,7 +67,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsRequest extends FBAOu
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsRequest extends FBAOu
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsRequest extends FBAOu
     /**
      * Check to see if PackageNumber is set.
      *
-     * @return true if PackageNumber is set.
+     * @return bool True if PackageNumber is set.
      */
     public function isSetPackageNumber()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetPackageTrackingDetailsResponse.php
+++ b/src/FBAOutboundServiceMWS/Model/GetPackageTrackingDetailsResponse.php
@@ -76,7 +76,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResponse extends FBAO
     /**
      * Check to see if GetPackageTrackingDetailsResult is set.
      *
-     * @return true if GetPackageTrackingDetailsResult is set.
+     * @return bool True if GetPackageTrackingDetailsResult is set.
      */
     public function isSetGetPackageTrackingDetailsResult()
     {
@@ -122,7 +122,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResponse extends FBAO
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResponse extends FBAO
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetPackageTrackingDetailsResult.php
+++ b/src/FBAOutboundServiceMWS/Model/GetPackageTrackingDetailsResult.php
@@ -91,7 +91,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if PackageNumber is set.
      *
-     * @return true if PackageNumber is set.
+     * @return bool True if PackageNumber is set.
      */
     public function isSetPackageNumber()
     {
@@ -137,7 +137,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if TrackingNumber is set.
      *
-     * @return true if TrackingNumber is set.
+     * @return bool True if TrackingNumber is set.
      */
     public function isSetTrackingNumber()
     {
@@ -183,7 +183,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if CarrierCode is set.
      *
-     * @return true if CarrierCode is set.
+     * @return bool True if CarrierCode is set.
      */
     public function isSetCarrierCode()
     {
@@ -229,7 +229,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if CarrierPhoneNumber is set.
      *
-     * @return true if CarrierPhoneNumber is set.
+     * @return bool True if CarrierPhoneNumber is set.
      */
     public function isSetCarrierPhoneNumber()
     {
@@ -275,7 +275,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if CarrierURL is set.
      *
-     * @return true if CarrierURL is set.
+     * @return bool True if CarrierURL is set.
      */
     public function isSetCarrierURL()
     {
@@ -321,7 +321,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if ShipDate is set.
      *
-     * @return true if ShipDate is set.
+     * @return bool True if ShipDate is set.
      */
     public function isSetShipDate()
     {
@@ -367,7 +367,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if EstimatedArrivalDate is set.
      *
-     * @return true if EstimatedArrivalDate is set.
+     * @return bool True if EstimatedArrivalDate is set.
      */
     public function isSetEstimatedArrivalDate()
     {
@@ -413,7 +413,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if ShipToAddress is set.
      *
-     * @return true if ShipToAddress is set.
+     * @return bool True if ShipToAddress is set.
      */
     public function isSetShipToAddress()
     {
@@ -459,7 +459,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if CurrentStatus is set.
      *
-     * @return true if CurrentStatus is set.
+     * @return bool True if CurrentStatus is set.
      */
     public function isSetCurrentStatus()
     {
@@ -505,7 +505,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if SignedForBy is set.
      *
-     * @return true if SignedForBy is set.
+     * @return bool True if SignedForBy is set.
      */
     public function isSetSignedForBy()
     {
@@ -551,7 +551,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if AdditionalLocationInfo is set.
      *
-     * @return true if AdditionalLocationInfo is set.
+     * @return bool True if AdditionalLocationInfo is set.
      */
     public function isSetAdditionalLocationInfo()
     {
@@ -597,7 +597,7 @@ class FBAOutboundServiceMWS_Model_GetPackageTrackingDetailsResult extends FBAOut
     /**
      * Check to see if TrackingEvents is set.
      *
-     * @return true if TrackingEvents is set.
+     * @return bool True if TrackingEvents is set.
      */
     public function isSetTrackingEvents()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetServiceStatusRequest.php
+++ b/src/FBAOutboundServiceMWS/Model/GetServiceStatusRequest.php
@@ -67,7 +67,7 @@ class FBAOutboundServiceMWS_Model_GetServiceStatusRequest extends FBAOutboundSer
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class FBAOutboundServiceMWS_Model_GetServiceStatusRequest extends FBAOutboundSer
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class FBAOutboundServiceMWS_Model_GetServiceStatusRequest extends FBAOutboundSer
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetServiceStatusResponse.php
+++ b/src/FBAOutboundServiceMWS/Model/GetServiceStatusResponse.php
@@ -76,7 +76,7 @@ class FBAOutboundServiceMWS_Model_GetServiceStatusResponse extends FBAOutboundSe
     /**
      * Check to see if GetServiceStatusResult is set.
      *
-     * @return true if GetServiceStatusResult is set.
+     * @return bool True if GetServiceStatusResult is set.
      */
     public function isSetGetServiceStatusResult()
     {
@@ -122,7 +122,7 @@ class FBAOutboundServiceMWS_Model_GetServiceStatusResponse extends FBAOutboundSe
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAOutboundServiceMWS_Model_GetServiceStatusResponse extends FBAOutboundSe
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAOutboundServiceMWS/Model/GetServiceStatusResult.php
+++ b/src/FBAOutboundServiceMWS/Model/GetServiceStatusResult.php
@@ -65,7 +65,7 @@ class FBAOutboundServiceMWS_Model_GetServiceStatusResult extends FBAOutboundServ
     /**
      * Check to see if Status is set.
      *
-     * @return true if Status is set.
+     * @return bool True if Status is set.
      */
     public function isSetStatus()
     {
@@ -111,7 +111,7 @@ class FBAOutboundServiceMWS_Model_GetServiceStatusResult extends FBAOutboundServ
     /**
      * Check to see if Timestamp is set.
      *
-     * @return true if Timestamp is set.
+     * @return bool True if Timestamp is set.
      */
     public function isSetTimestamp()
     {

--- a/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersByNextTokenRequest.php
+++ b/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersByNextTokenRequest.php
@@ -69,7 +69,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersByNextTokenRequest ext
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -115,7 +115,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersByNextTokenRequest ext
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -161,7 +161,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersByNextTokenRequest ext
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -207,7 +207,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersByNextTokenRequest ext
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersByNextTokenResponse.php
+++ b/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersByNextTokenResponse.php
@@ -76,7 +76,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersByNextTokenResponse ex
     /**
      * Check to see if ListAllFulfillmentOrdersByNextTokenResult is set.
      *
-     * @return true if ListAllFulfillmentOrdersByNextTokenResult is set.
+     * @return bool True if ListAllFulfillmentOrdersByNextTokenResult is set.
      */
     public function isSetListAllFulfillmentOrdersByNextTokenResult()
     {
@@ -122,7 +122,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersByNextTokenResponse ex
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersByNextTokenResponse ex
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersByNextTokenResult.php
+++ b/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersByNextTokenResult.php
@@ -68,7 +68,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersByNextTokenResult exte
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -114,7 +114,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersByNextTokenResult exte
     /**
      * Check to see if FulfillmentOrders is set.
      *
-     * @return true if FulfillmentOrders is set.
+     * @return bool True if FulfillmentOrders is set.
      */
     public function isSetFulfillmentOrders()
     {

--- a/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersRequest.php
+++ b/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersRequest.php
@@ -74,7 +74,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersRequest extends FBAOut
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -120,7 +120,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersRequest extends FBAOut
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -166,7 +166,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersRequest extends FBAOut
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -212,7 +212,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersRequest extends FBAOut
     /**
      * Check to see if QueryStartDateTime is set.
      *
-     * @return true if QueryStartDateTime is set.
+     * @return bool True if QueryStartDateTime is set.
      */
     public function isSetQueryStartDateTime()
     {
@@ -258,7 +258,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersRequest extends FBAOut
     /**
      * Check to see if FulfillmentMethod is set.
      *
-     * @return true if FulfillmentMethod is set.
+     * @return bool True if FulfillmentMethod is set.
      */
     public function isSetFulfillmentMethod()
     {

--- a/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersResponse.php
+++ b/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersResponse.php
@@ -76,7 +76,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersResponse extends FBAOu
     /**
      * Check to see if ListAllFulfillmentOrdersResult is set.
      *
-     * @return true if ListAllFulfillmentOrdersResult is set.
+     * @return bool True if ListAllFulfillmentOrdersResult is set.
      */
     public function isSetListAllFulfillmentOrdersResult()
     {
@@ -122,7 +122,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersResponse extends FBAOu
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersResponse extends FBAOu
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersResult.php
+++ b/src/FBAOutboundServiceMWS/Model/ListAllFulfillmentOrdersResult.php
@@ -68,7 +68,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersResult extends FBAOutb
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -114,7 +114,7 @@ class FBAOutboundServiceMWS_Model_ListAllFulfillmentOrdersResult extends FBAOutb
     /**
      * Check to see if FulfillmentOrders is set.
      *
-     * @return true if FulfillmentOrders is set.
+     * @return bool True if FulfillmentOrders is set.
      */
     public function isSetFulfillmentOrders()
     {

--- a/src/FBAOutboundServiceMWS/Model/NotificationEmailList.php
+++ b/src/FBAOutboundServiceMWS/Model/NotificationEmailList.php
@@ -77,7 +77,7 @@ class FBAOutboundServiceMWS_Model_NotificationEmailList extends FBAOutboundServi
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/ResponseMetadata.php
+++ b/src/FBAOutboundServiceMWS/Model/ResponseMetadata.php
@@ -63,7 +63,7 @@ class FBAOutboundServiceMWS_Model_ResponseMetadata extends FBAOutboundServiceMWS
     /**
      * Check to see if RequestId is set.
      *
-     * @return true if RequestId is set.
+     * @return bool True if RequestId is set.
      */
     public function isSetRequestId()
     {

--- a/src/FBAOutboundServiceMWS/Model/ScheduledDeliveryInfo.php
+++ b/src/FBAOutboundServiceMWS/Model/ScheduledDeliveryInfo.php
@@ -68,7 +68,7 @@ class FBAOutboundServiceMWS_Model_ScheduledDeliveryInfo extends FBAOutboundServi
     /**
      * Check to see if DeliveryTimeZone is set.
      *
-     * @return true if DeliveryTimeZone is set.
+     * @return bool True if DeliveryTimeZone is set.
      */
     public function isSetDeliveryTimeZone()
     {
@@ -114,7 +114,7 @@ class FBAOutboundServiceMWS_Model_ScheduledDeliveryInfo extends FBAOutboundServi
     /**
      * Check to see if DeliveryWindows is set.
      *
-     * @return true if DeliveryWindows is set.
+     * @return bool True if DeliveryWindows is set.
      */
     public function isSetDeliveryWindows()
     {

--- a/src/FBAOutboundServiceMWS/Model/ShippingSpeedCategoryList.php
+++ b/src/FBAOutboundServiceMWS/Model/ShippingSpeedCategoryList.php
@@ -77,7 +77,7 @@ class FBAOutboundServiceMWS_Model_ShippingSpeedCategoryList extends FBAOutboundS
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/StringList.php
+++ b/src/FBAOutboundServiceMWS/Model/StringList.php
@@ -77,7 +77,7 @@ class FBAOutboundServiceMWS_Model_StringList extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/TrackingAddress.php
+++ b/src/FBAOutboundServiceMWS/Model/TrackingAddress.php
@@ -67,7 +67,7 @@ class FBAOutboundServiceMWS_Model_TrackingAddress extends FBAOutboundServiceMWS_
     /**
      * Check to see if City is set.
      *
-     * @return true if City is set.
+     * @return bool True if City is set.
      */
     public function isSetCity()
     {
@@ -113,7 +113,7 @@ class FBAOutboundServiceMWS_Model_TrackingAddress extends FBAOutboundServiceMWS_
     /**
      * Check to see if State is set.
      *
-     * @return true if State is set.
+     * @return bool True if State is set.
      */
     public function isSetState()
     {
@@ -159,7 +159,7 @@ class FBAOutboundServiceMWS_Model_TrackingAddress extends FBAOutboundServiceMWS_
     /**
      * Check to see if Country is set.
      *
-     * @return true if Country is set.
+     * @return bool True if Country is set.
      */
     public function isSetCountry()
     {

--- a/src/FBAOutboundServiceMWS/Model/TrackingEvent.php
+++ b/src/FBAOutboundServiceMWS/Model/TrackingEvent.php
@@ -67,7 +67,7 @@ class FBAOutboundServiceMWS_Model_TrackingEvent extends FBAOutboundServiceMWS_Mo
     /**
      * Check to see if EventDate is set.
      *
-     * @return true if EventDate is set.
+     * @return bool True if EventDate is set.
      */
     public function isSetEventDate()
     {
@@ -113,7 +113,7 @@ class FBAOutboundServiceMWS_Model_TrackingEvent extends FBAOutboundServiceMWS_Mo
     /**
      * Check to see if EventAddress is set.
      *
-     * @return true if EventAddress is set.
+     * @return bool True if EventAddress is set.
      */
     public function isSetEventAddress()
     {
@@ -159,7 +159,7 @@ class FBAOutboundServiceMWS_Model_TrackingEvent extends FBAOutboundServiceMWS_Mo
     /**
      * Check to see if EventCode is set.
      *
-     * @return true if EventCode is set.
+     * @return bool True if EventCode is set.
      */
     public function isSetEventCode()
     {

--- a/src/FBAOutboundServiceMWS/Model/TrackingEventList.php
+++ b/src/FBAOutboundServiceMWS/Model/TrackingEventList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_TrackingEventList extends FBAOutboundServiceMW
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/UnfulfillablePreviewItem.php
+++ b/src/FBAOutboundServiceMWS/Model/UnfulfillablePreviewItem.php
@@ -72,7 +72,7 @@ class FBAOutboundServiceMWS_Model_UnfulfillablePreviewItem extends FBAOutboundSe
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -118,7 +118,7 @@ class FBAOutboundServiceMWS_Model_UnfulfillablePreviewItem extends FBAOutboundSe
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {
@@ -164,7 +164,7 @@ class FBAOutboundServiceMWS_Model_UnfulfillablePreviewItem extends FBAOutboundSe
     /**
      * Check to see if SellerFulfillmentOrderItemId is set.
      *
-     * @return true if SellerFulfillmentOrderItemId is set.
+     * @return bool True if SellerFulfillmentOrderItemId is set.
      */
     public function isSetSellerFulfillmentOrderItemId()
     {
@@ -210,7 +210,7 @@ class FBAOutboundServiceMWS_Model_UnfulfillablePreviewItem extends FBAOutboundSe
     /**
      * Check to see if ItemUnfulfillableReasons is set.
      *
-     * @return true if ItemUnfulfillableReasons is set.
+     * @return bool True if ItemUnfulfillableReasons is set.
      */
     public function isSetItemUnfulfillableReasons()
     {

--- a/src/FBAOutboundServiceMWS/Model/UnfulfillablePreviewItemList.php
+++ b/src/FBAOutboundServiceMWS/Model/UnfulfillablePreviewItemList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_UnfulfillablePreviewItemList extends FBAOutbou
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/UpdateFulfillmentOrderItem.php
+++ b/src/FBAOutboundServiceMWS/Model/UpdateFulfillmentOrderItem.php
@@ -84,7 +84,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -130,7 +130,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if SellerFulfillmentOrderItemId is set.
      *
-     * @return true if SellerFulfillmentOrderItemId is set.
+     * @return bool True if SellerFulfillmentOrderItemId is set.
      */
     public function isSetSellerFulfillmentOrderItemId()
     {
@@ -176,7 +176,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {
@@ -222,7 +222,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if GiftMessage is set.
      *
-     * @return true if GiftMessage is set.
+     * @return bool True if GiftMessage is set.
      */
     public function isSetGiftMessage()
     {
@@ -268,7 +268,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if DisplayableComment is set.
      *
-     * @return true if DisplayableComment is set.
+     * @return bool True if DisplayableComment is set.
      */
     public function isSetDisplayableComment()
     {
@@ -314,7 +314,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if FulfillmentNetworkSKU is set.
      *
-     * @return true if FulfillmentNetworkSKU is set.
+     * @return bool True if FulfillmentNetworkSKU is set.
      */
     public function isSetFulfillmentNetworkSKU()
     {
@@ -360,7 +360,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if OrderItemDisposition is set.
      *
-     * @return true if OrderItemDisposition is set.
+     * @return bool True if OrderItemDisposition is set.
      */
     public function isSetOrderItemDisposition()
     {
@@ -406,7 +406,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if PerUnitDeclaredValue is set.
      *
-     * @return true if PerUnitDeclaredValue is set.
+     * @return bool True if PerUnitDeclaredValue is set.
      */
     public function isSetPerUnitDeclaredValue()
     {
@@ -452,7 +452,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if PerUnitPrice is set.
      *
-     * @return true if PerUnitPrice is set.
+     * @return bool True if PerUnitPrice is set.
      */
     public function isSetPerUnitPrice()
     {
@@ -498,7 +498,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderItem extends FBAOutbound
     /**
      * Check to see if PerUnitTax is set.
      *
-     * @return true if PerUnitTax is set.
+     * @return bool True if PerUnitTax is set.
      */
     public function isSetPerUnitTax()
     {

--- a/src/FBAOutboundServiceMWS/Model/UpdateFulfillmentOrderItemList.php
+++ b/src/FBAOutboundServiceMWS/Model/UpdateFulfillmentOrderItemList.php
@@ -80,7 +80,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderItemList extends FBAOutb
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/FBAOutboundServiceMWS/Model/UpdateFulfillmentOrderRequest.php
+++ b/src/FBAOutboundServiceMWS/Model/UpdateFulfillmentOrderRequest.php
@@ -97,7 +97,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -143,7 +143,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -189,7 +189,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {
@@ -235,7 +235,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if SellerFulfillmentOrderId is set.
      *
-     * @return true if SellerFulfillmentOrderId is set.
+     * @return bool True if SellerFulfillmentOrderId is set.
      */
     public function isSetSellerFulfillmentOrderId()
     {
@@ -281,7 +281,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if DisplayableOrderId is set.
      *
-     * @return true if DisplayableOrderId is set.
+     * @return bool True if DisplayableOrderId is set.
      */
     public function isSetDisplayableOrderId()
     {
@@ -327,7 +327,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if DisplayableOrderDateTime is set.
      *
-     * @return true if DisplayableOrderDateTime is set.
+     * @return bool True if DisplayableOrderDateTime is set.
      */
     public function isSetDisplayableOrderDateTime()
     {
@@ -373,7 +373,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if DisplayableOrderComment is set.
      *
-     * @return true if DisplayableOrderComment is set.
+     * @return bool True if DisplayableOrderComment is set.
      */
     public function isSetDisplayableOrderComment()
     {
@@ -419,7 +419,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if ShippingSpeedCategory is set.
      *
-     * @return true if ShippingSpeedCategory is set.
+     * @return bool True if ShippingSpeedCategory is set.
      */
     public function isSetShippingSpeedCategory()
     {
@@ -465,7 +465,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if DestinationAddress is set.
      *
-     * @return true if DestinationAddress is set.
+     * @return bool True if DestinationAddress is set.
      */
     public function isSetDestinationAddress()
     {
@@ -511,7 +511,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if FulfillmentAction is set.
      *
-     * @return true if FulfillmentAction is set.
+     * @return bool True if FulfillmentAction is set.
      */
     public function isSetFulfillmentAction()
     {
@@ -557,7 +557,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if FulfillmentPolicy is set.
      *
-     * @return true if FulfillmentPolicy is set.
+     * @return bool True if FulfillmentPolicy is set.
      */
     public function isSetFulfillmentPolicy()
     {
@@ -603,7 +603,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if FulfillmentMethod is set.
      *
-     * @return true if FulfillmentMethod is set.
+     * @return bool True if FulfillmentMethod is set.
      */
     public function isSetFulfillmentMethod()
     {
@@ -649,7 +649,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if ShipFromCountryCode is set.
      *
-     * @return true if ShipFromCountryCode is set.
+     * @return bool True if ShipFromCountryCode is set.
      */
     public function isSetShipFromCountryCode()
     {
@@ -695,7 +695,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if NotificationEmailList is set.
      *
-     * @return true if NotificationEmailList is set.
+     * @return bool True if NotificationEmailList is set.
      */
     public function isSetNotificationEmailList()
     {
@@ -741,7 +741,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderRequest extends FBAOutbo
     /**
      * Check to see if Items is set.
      *
-     * @return true if Items is set.
+     * @return bool True if Items is set.
      */
     public function isSetItems()
     {

--- a/src/FBAOutboundServiceMWS/Model/UpdateFulfillmentOrderResponse.php
+++ b/src/FBAOutboundServiceMWS/Model/UpdateFulfillmentOrderResponse.php
@@ -71,7 +71,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderResponse extends FBAOutb
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -117,7 +117,7 @@ class FBAOutboundServiceMWS_Model_UpdateFulfillmentOrderResponse extends FBAOutb
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/FBAOutboundServiceMWS/Model/Weight.php
+++ b/src/FBAOutboundServiceMWS/Model/Weight.php
@@ -65,7 +65,7 @@ class FBAOutboundServiceMWS_Model_Weight extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if Unit is set.
      *
-     * @return true if Unit is set.
+     * @return bool True if Unit is set.
      */
     public function isSetUnit()
     {
@@ -111,7 +111,7 @@ class FBAOutboundServiceMWS_Model_Weight extends FBAOutboundServiceMWS_Model
     /**
      * Check to see if Value is set.
      *
-     * @return true if Value is set.
+     * @return bool True if Value is set.
      */
     public function isSetValue()
     {

--- a/src/MWSFinancesService/Model.php
+++ b/src/MWSFinancesService/Model.php
@@ -400,7 +400,7 @@ abstract class MWSFinancesService_Model
     * Checks  whether passed variable is an associative array
     *
     * @param mixed $var
-    * @return TRUE if passed variable is an associative array
+    * @return bool True if passed variable is an associative array
     */
     private function _isAssociativeArray($var)
     {
@@ -411,7 +411,7 @@ abstract class MWSFinancesService_Model
     * Checks  whether passed variable is DOMElement
     *
     * @param mixed $var
-    * @return TRUE if passed variable is DOMElement
+    * @return bool True if passed variable is DOMElement
     */
     private function _isDOMElement($var)
     {
@@ -422,7 +422,7 @@ abstract class MWSFinancesService_Model
     * Checks  whether passed variable is numeric array
     *
     * @param mixed $var
-    * @return TRUE if passed variable is an numeric array
+    * @return bool True if passed variable is an numeric array
     */
     protected function _isNumericArray($var)
     {

--- a/src/MWSFinancesService/Model/AdjustmentEvent.php
+++ b/src/MWSFinancesService/Model/AdjustmentEvent.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AdjustmentType is set.
      *
-     * @return true if AdjustmentType is set.
+     * @return bool True if AdjustmentType is set.
      */
     public function isSetAdjustmentType()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AdjustmentAmount is set.
      *
-     * @return true if AdjustmentAmount is set.
+     * @return bool True if AdjustmentAmount is set.
      */
     public function isSetAdjustmentAmount()
     {
@@ -181,7 +181,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AdjustmentItemList is set.
      *
-     * @return true if AdjustmentItemList is set.
+     * @return bool True if AdjustmentItemList is set.
      */
     public function isSetAdjustmentItemList()
     {

--- a/src/MWSFinancesService/Model/AdjustmentItem.php
+++ b/src/MWSFinancesService/Model/AdjustmentItem.php
@@ -82,7 +82,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {
@@ -128,7 +128,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PerUnitAmount is set.
      *
-     * @return true if PerUnitAmount is set.
+     * @return bool True if PerUnitAmount is set.
      */
     public function isSetPerUnitAmount()
     {
@@ -174,7 +174,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if TotalAmount is set.
      *
-     * @return true if TotalAmount is set.
+     * @return bool True if TotalAmount is set.
      */
     public function isSetTotalAmount()
     {
@@ -220,7 +220,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -266,7 +266,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FnSKU is set.
      *
-     * @return true if FnSKU is set.
+     * @return bool True if FnSKU is set.
      */
     public function isSetFnSKU()
     {
@@ -312,7 +312,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ProductDescription is set.
      *
-     * @return true if ProductDescription is set.
+     * @return bool True if ProductDescription is set.
      */
     public function isSetProductDescription()
     {
@@ -358,7 +358,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {

--- a/src/MWSFinancesService/Model/ChargeComponent.php
+++ b/src/MWSFinancesService/Model/ChargeComponent.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ChargeType is set.
      *
-     * @return true if ChargeType is set.
+     * @return bool True if ChargeType is set.
      */
     public function isSetChargeType()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ChargeAmount is set.
      *
-     * @return true if ChargeAmount is set.
+     * @return bool True if ChargeAmount is set.
      */
     public function isSetChargeAmount()
     {

--- a/src/MWSFinancesService/Model/ChargeInstrument.php
+++ b/src/MWSFinancesService/Model/ChargeInstrument.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Description is set.
      *
-     * @return true if Description is set.
+     * @return bool True if Description is set.
      */
     public function isSetDescription()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Tail is set.
      *
-     * @return true if Tail is set.
+     * @return bool True if Tail is set.
      */
     public function isSetTail()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Amount is set.
      *
-     * @return true if Amount is set.
+     * @return bool True if Amount is set.
      */
     public function isSetAmount()
     {

--- a/src/MWSFinancesService/Model/Currency.php
+++ b/src/MWSFinancesService/Model/Currency.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CurrencyCode is set.
      *
-     * @return true if CurrencyCode is set.
+     * @return bool True if CurrencyCode is set.
      */
     public function isSetCurrencyCode()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CurrencyAmount is set.
      *
-     * @return true if CurrencyAmount is set.
+     * @return bool True if CurrencyAmount is set.
      */
     public function isSetCurrencyAmount()
     {

--- a/src/MWSFinancesService/Model/DebtRecoveryEvent.php
+++ b/src/MWSFinancesService/Model/DebtRecoveryEvent.php
@@ -78,7 +78,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DebtRecoveryType is set.
      *
-     * @return true if DebtRecoveryType is set.
+     * @return bool True if DebtRecoveryType is set.
      */
     public function isSetDebtRecoveryType()
     {
@@ -124,7 +124,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecoveryAmount is set.
      *
-     * @return true if RecoveryAmount is set.
+     * @return bool True if RecoveryAmount is set.
      */
     public function isSetRecoveryAmount()
     {
@@ -170,7 +170,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if OverPaymentCredit is set.
      *
-     * @return true if OverPaymentCredit is set.
+     * @return bool True if OverPaymentCredit is set.
      */
     public function isSetOverPaymentCredit()
     {
@@ -231,7 +231,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DebtRecoveryItemList is set.
      *
-     * @return true if DebtRecoveryItemList is set.
+     * @return bool True if DebtRecoveryItemList is set.
      */
     public function isSetDebtRecoveryItemList()
     {
@@ -295,7 +295,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ChargeInstrumentList is set.
      *
-     * @return true if ChargeInstrumentList is set.
+     * @return bool True if ChargeInstrumentList is set.
      */
     public function isSetChargeInstrumentList()
     {

--- a/src/MWSFinancesService/Model/DebtRecoveryItem.php
+++ b/src/MWSFinancesService/Model/DebtRecoveryItem.php
@@ -76,7 +76,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecoveryAmount is set.
      *
-     * @return true if RecoveryAmount is set.
+     * @return bool True if RecoveryAmount is set.
      */
     public function isSetRecoveryAmount()
     {
@@ -122,7 +122,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if OriginalAmount is set.
      *
-     * @return true if OriginalAmount is set.
+     * @return bool True if OriginalAmount is set.
      */
     public function isSetOriginalAmount()
     {
@@ -168,7 +168,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GroupBeginDate is set.
      *
-     * @return true if GroupBeginDate is set.
+     * @return bool True if GroupBeginDate is set.
      */
     public function isSetGroupBeginDate()
     {
@@ -214,7 +214,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GroupEndDate is set.
      *
-     * @return true if GroupEndDate is set.
+     * @return bool True if GroupEndDate is set.
      */
     public function isSetGroupEndDate()
     {

--- a/src/MWSFinancesService/Model/DirectPayment.php
+++ b/src/MWSFinancesService/Model/DirectPayment.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DirectPaymentType is set.
      *
-     * @return true if DirectPaymentType is set.
+     * @return bool True if DirectPaymentType is set.
      */
     public function isSetDirectPaymentType()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DirectPaymentAmount is set.
      *
-     * @return true if DirectPaymentAmount is set.
+     * @return bool True if DirectPaymentAmount is set.
      */
     public function isSetDirectPaymentAmount()
     {

--- a/src/MWSFinancesService/Model/FeeComponent.php
+++ b/src/MWSFinancesService/Model/FeeComponent.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FeeType is set.
      *
-     * @return true if FeeType is set.
+     * @return bool True if FeeType is set.
      */
     public function isSetFeeType()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FeeAmount is set.
      *
-     * @return true if FeeAmount is set.
+     * @return bool True if FeeAmount is set.
      */
     public function isSetFeeAmount()
     {

--- a/src/MWSFinancesService/Model/FinancialEventGroup.php
+++ b/src/MWSFinancesService/Model/FinancialEventGroup.php
@@ -90,7 +90,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FinancialEventGroupId is set.
      *
-     * @return true if FinancialEventGroupId is set.
+     * @return bool True if FinancialEventGroupId is set.
      */
     public function isSetFinancialEventGroupId()
     {
@@ -136,7 +136,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ProcessingStatus is set.
      *
-     * @return true if ProcessingStatus is set.
+     * @return bool True if ProcessingStatus is set.
      */
     public function isSetProcessingStatus()
     {
@@ -182,7 +182,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FundTransferStatus is set.
      *
-     * @return true if FundTransferStatus is set.
+     * @return bool True if FundTransferStatus is set.
      */
     public function isSetFundTransferStatus()
     {
@@ -228,7 +228,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if OriginalTotal is set.
      *
-     * @return true if OriginalTotal is set.
+     * @return bool True if OriginalTotal is set.
      */
     public function isSetOriginalTotal()
     {
@@ -274,7 +274,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ConvertedTotal is set.
      *
-     * @return true if ConvertedTotal is set.
+     * @return bool True if ConvertedTotal is set.
      */
     public function isSetConvertedTotal()
     {
@@ -320,7 +320,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FundTransferDate is set.
      *
-     * @return true if FundTransferDate is set.
+     * @return bool True if FundTransferDate is set.
      */
     public function isSetFundTransferDate()
     {
@@ -366,7 +366,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if TraceId is set.
      *
-     * @return true if TraceId is set.
+     * @return bool True if TraceId is set.
      */
     public function isSetTraceId()
     {
@@ -412,7 +412,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AccountTail is set.
      *
-     * @return true if AccountTail is set.
+     * @return bool True if AccountTail is set.
      */
     public function isSetAccountTail()
     {
@@ -458,7 +458,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if BeginningBalance is set.
      *
-     * @return true if BeginningBalance is set.
+     * @return bool True if BeginningBalance is set.
      */
     public function isSetBeginningBalance()
     {
@@ -504,7 +504,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FinancialEventGroupStart is set.
      *
-     * @return true if FinancialEventGroupStart is set.
+     * @return bool True if FinancialEventGroupStart is set.
      */
     public function isSetFinancialEventGroupStart()
     {
@@ -550,7 +550,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FinancialEventGroupEnd is set.
      *
-     * @return true if FinancialEventGroupEnd is set.
+     * @return bool True if FinancialEventGroupEnd is set.
      */
     public function isSetFinancialEventGroupEnd()
     {

--- a/src/MWSFinancesService/Model/FinancialEvents.php
+++ b/src/MWSFinancesService/Model/FinancialEvents.php
@@ -109,7 +109,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipmentEventList is set.
      *
-     * @return true if ShipmentEventList is set.
+     * @return bool True if ShipmentEventList is set.
      */
     public function isSetShipmentEventList()
     {
@@ -173,7 +173,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RefundEventList is set.
      *
-     * @return true if RefundEventList is set.
+     * @return bool True if RefundEventList is set.
      */
     public function isSetRefundEventList()
     {
@@ -237,7 +237,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GuaranteeClaimEventList is set.
      *
-     * @return true if GuaranteeClaimEventList is set.
+     * @return bool True if GuaranteeClaimEventList is set.
      */
     public function isSetGuaranteeClaimEventList()
     {
@@ -301,7 +301,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ChargebackEventList is set.
      *
-     * @return true if ChargebackEventList is set.
+     * @return bool True if ChargebackEventList is set.
      */
     public function isSetChargebackEventList()
     {
@@ -365,7 +365,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PayWithAmazonEventList is set.
      *
-     * @return true if PayWithAmazonEventList is set.
+     * @return bool True if PayWithAmazonEventList is set.
      */
     public function isSetPayWithAmazonEventList()
     {
@@ -429,7 +429,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ServiceProviderCreditEventList is set.
      *
-     * @return true if ServiceProviderCreditEventList is set.
+     * @return bool True if ServiceProviderCreditEventList is set.
      */
     public function isSetServiceProviderCreditEventList()
     {
@@ -493,7 +493,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RetrochargeEventList is set.
      *
-     * @return true if RetrochargeEventList is set.
+     * @return bool True if RetrochargeEventList is set.
      */
     public function isSetRetrochargeEventList()
     {
@@ -557,7 +557,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RentalTransactionEventList is set.
      *
-     * @return true if RentalTransactionEventList is set.
+     * @return bool True if RentalTransactionEventList is set.
      */
     public function isSetRentalTransactionEventList()
     {
@@ -621,7 +621,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PerformanceBondRefundEventList is set.
      *
-     * @return true if PerformanceBondRefundEventList is set.
+     * @return bool True if PerformanceBondRefundEventList is set.
      */
     public function isSetPerformanceBondRefundEventList()
     {
@@ -685,7 +685,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ServiceFeeEventList is set.
      *
-     * @return true if ServiceFeeEventList is set.
+     * @return bool True if ServiceFeeEventList is set.
      */
     public function isSetServiceFeeEventList()
     {
@@ -749,7 +749,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DebtRecoveryEventList is set.
      *
-     * @return true if DebtRecoveryEventList is set.
+     * @return bool True if DebtRecoveryEventList is set.
      */
     public function isSetDebtRecoveryEventList()
     {
@@ -813,7 +813,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LoanServicingEventList is set.
      *
-     * @return true if LoanServicingEventList is set.
+     * @return bool True if LoanServicingEventList is set.
      */
     public function isSetLoanServicingEventList()
     {
@@ -877,7 +877,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AdjustmentEventList is set.
      *
-     * @return true if AdjustmentEventList is set.
+     * @return bool True if AdjustmentEventList is set.
      */
     public function isSetAdjustmentEventList()
     {

--- a/src/MWSFinancesService/Model/GetServiceStatusRequest.php
+++ b/src/MWSFinancesService/Model/GetServiceStatusRequest.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {

--- a/src/MWSFinancesService/Model/GetServiceStatusResponse.php
+++ b/src/MWSFinancesService/Model/GetServiceStatusResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GetServiceStatusResult is set.
      *
-     * @return true if GetServiceStatusResult is set.
+     * @return bool True if GetServiceStatusResult is set.
      */
     public function isSetGetServiceStatusResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSFinancesService/Model/GetServiceStatusResult.php
+++ b/src/MWSFinancesService/Model/GetServiceStatusResult.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Status is set.
      *
-     * @return true if Status is set.
+     * @return bool True if Status is set.
      */
     public function isSetStatus()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Timestamp is set.
      *
-     * @return true if Timestamp is set.
+     * @return bool True if Timestamp is set.
      */
     public function isSetTimestamp()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventGroupsByNextTokenRequest.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventGroupsByNextTokenRequest.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventGroupsByNextTokenResponse.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventGroupsByNextTokenResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ListFinancialEventGroupsByNextTokenResult is set.
      *
-     * @return true if ListFinancialEventGroupsByNextTokenResult is set.
+     * @return bool True if ListFinancialEventGroupsByNextTokenResult is set.
      */
     public function isSetListFinancialEventGroupsByNextTokenResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventGroupsByNextTokenResult.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventGroupsByNextTokenResult.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -133,7 +133,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FinancialEventGroupList is set.
      *
-     * @return true if FinancialEventGroupList is set.
+     * @return bool True if FinancialEventGroupList is set.
      */
     public function isSetFinancialEventGroupList()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventGroupsRequest.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventGroupsRequest.php
@@ -78,7 +78,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -124,7 +124,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -170,7 +170,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MaxResultsPerPage is set.
      *
-     * @return true if MaxResultsPerPage is set.
+     * @return bool True if MaxResultsPerPage is set.
      */
     public function isSetMaxResultsPerPage()
     {
@@ -216,7 +216,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FinancialEventGroupStartedAfter is set.
      *
-     * @return true if FinancialEventGroupStartedAfter is set.
+     * @return bool True if FinancialEventGroupStartedAfter is set.
      */
     public function isSetFinancialEventGroupStartedAfter()
     {
@@ -262,7 +262,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FinancialEventGroupStartedBefore is set.
      *
-     * @return true if FinancialEventGroupStartedBefore is set.
+     * @return bool True if FinancialEventGroupStartedBefore is set.
      */
     public function isSetFinancialEventGroupStartedBefore()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventGroupsResponse.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventGroupsResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ListFinancialEventGroupsResult is set.
      *
-     * @return true if ListFinancialEventGroupsResult is set.
+     * @return bool True if ListFinancialEventGroupsResult is set.
      */
     public function isSetListFinancialEventGroupsResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventGroupsResult.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventGroupsResult.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -133,7 +133,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FinancialEventGroupList is set.
      *
-     * @return true if FinancialEventGroupList is set.
+     * @return bool True if FinancialEventGroupList is set.
      */
     public function isSetFinancialEventGroupList()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventsByNextTokenRequest.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventsByNextTokenRequest.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventsByNextTokenResponse.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventsByNextTokenResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ListFinancialEventsByNextTokenResult is set.
      *
-     * @return true if ListFinancialEventsByNextTokenResult is set.
+     * @return bool True if ListFinancialEventsByNextTokenResult is set.
      */
     public function isSetListFinancialEventsByNextTokenResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventsByNextTokenResult.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventsByNextTokenResult.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FinancialEvents is set.
      *
-     * @return true if FinancialEvents is set.
+     * @return bool True if FinancialEvents is set.
      */
     public function isSetFinancialEvents()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventsRequest.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventsRequest.php
@@ -82,7 +82,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -128,7 +128,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -174,7 +174,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MaxResultsPerPage is set.
      *
-     * @return true if MaxResultsPerPage is set.
+     * @return bool True if MaxResultsPerPage is set.
      */
     public function isSetMaxResultsPerPage()
     {
@@ -220,7 +220,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {
@@ -266,7 +266,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FinancialEventGroupId is set.
      *
-     * @return true if FinancialEventGroupId is set.
+     * @return bool True if FinancialEventGroupId is set.
      */
     public function isSetFinancialEventGroupId()
     {
@@ -312,7 +312,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PostedAfter is set.
      *
-     * @return true if PostedAfter is set.
+     * @return bool True if PostedAfter is set.
      */
     public function isSetPostedAfter()
     {
@@ -358,7 +358,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PostedBefore is set.
      *
-     * @return true if PostedBefore is set.
+     * @return bool True if PostedBefore is set.
      */
     public function isSetPostedBefore()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventsResponse.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventsResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ListFinancialEventsResult is set.
      *
-     * @return true if ListFinancialEventsResult is set.
+     * @return bool True if ListFinancialEventsResult is set.
      */
     public function isSetListFinancialEventsResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSFinancesService/Model/ListFinancialEventsResult.php
+++ b/src/MWSFinancesService/Model/ListFinancialEventsResult.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FinancialEvents is set.
      *
-     * @return true if FinancialEvents is set.
+     * @return bool True if FinancialEvents is set.
      */
     public function isSetFinancialEvents()
     {

--- a/src/MWSFinancesService/Model/LoanServicingEvent.php
+++ b/src/MWSFinancesService/Model/LoanServicingEvent.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LoanAmount is set.
      *
-     * @return true if LoanAmount is set.
+     * @return bool True if LoanAmount is set.
      */
     public function isSetLoanAmount()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SourceBusinessEventType is set.
      *
-     * @return true if SourceBusinessEventType is set.
+     * @return bool True if SourceBusinessEventType is set.
      */
     public function isSetSourceBusinessEventType()
     {

--- a/src/MWSFinancesService/Model/PayWithAmazonEvent.php
+++ b/src/MWSFinancesService/Model/PayWithAmazonEvent.php
@@ -88,7 +88,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerOrderId is set.
      *
-     * @return true if SellerOrderId is set.
+     * @return bool True if SellerOrderId is set.
      */
     public function isSetSellerOrderId()
     {
@@ -134,7 +134,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if TransactionPostedDate is set.
      *
-     * @return true if TransactionPostedDate is set.
+     * @return bool True if TransactionPostedDate is set.
      */
     public function isSetTransactionPostedDate()
     {
@@ -180,7 +180,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if BusinessObjectType is set.
      *
-     * @return true if BusinessObjectType is set.
+     * @return bool True if BusinessObjectType is set.
      */
     public function isSetBusinessObjectType()
     {
@@ -226,7 +226,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SalesChannel is set.
      *
-     * @return true if SalesChannel is set.
+     * @return bool True if SalesChannel is set.
      */
     public function isSetSalesChannel()
     {
@@ -272,7 +272,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Charge is set.
      *
-     * @return true if Charge is set.
+     * @return bool True if Charge is set.
      */
     public function isSetCharge()
     {
@@ -333,7 +333,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FeeList is set.
      *
-     * @return true if FeeList is set.
+     * @return bool True if FeeList is set.
      */
     public function isSetFeeList()
     {
@@ -382,7 +382,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PaymentAmountType is set.
      *
-     * @return true if PaymentAmountType is set.
+     * @return bool True if PaymentAmountType is set.
      */
     public function isSetPaymentAmountType()
     {
@@ -428,7 +428,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AmountDescription is set.
      *
-     * @return true if AmountDescription is set.
+     * @return bool True if AmountDescription is set.
      */
     public function isSetAmountDescription()
     {
@@ -474,7 +474,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FulfillmentChannel is set.
      *
-     * @return true if FulfillmentChannel is set.
+     * @return bool True if FulfillmentChannel is set.
      */
     public function isSetFulfillmentChannel()
     {
@@ -520,7 +520,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if StoreName is set.
      *
-     * @return true if StoreName is set.
+     * @return bool True if StoreName is set.
      */
     public function isSetStoreName()
     {

--- a/src/MWSFinancesService/Model/PerformanceBondRefundEvent.php
+++ b/src/MWSFinancesService/Model/PerformanceBondRefundEvent.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceCountryCode is set.
      *
-     * @return true if MarketplaceCountryCode is set.
+     * @return bool True if MarketplaceCountryCode is set.
      */
     public function isSetMarketplaceCountryCode()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Amount is set.
      *
-     * @return true if Amount is set.
+     * @return bool True if Amount is set.
      */
     public function isSetAmount()
     {
@@ -181,7 +181,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ProductGroupList is set.
      *
-     * @return true if ProductGroupList is set.
+     * @return bool True if ProductGroupList is set.
      */
     public function isSetProductGroupList()
     {

--- a/src/MWSFinancesService/Model/Promotion.php
+++ b/src/MWSFinancesService/Model/Promotion.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PromotionType is set.
      *
-     * @return true if PromotionType is set.
+     * @return bool True if PromotionType is set.
      */
     public function isSetPromotionType()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PromotionId is set.
      *
-     * @return true if PromotionId is set.
+     * @return bool True if PromotionId is set.
      */
     public function isSetPromotionId()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PromotionAmount is set.
      *
-     * @return true if PromotionAmount is set.
+     * @return bool True if PromotionAmount is set.
      */
     public function isSetPromotionAmount()
     {

--- a/src/MWSFinancesService/Model/RentalTransactionEvent.php
+++ b/src/MWSFinancesService/Model/RentalTransactionEvent.php
@@ -86,7 +86,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {
@@ -132,7 +132,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RentalEventType is set.
      *
-     * @return true if RentalEventType is set.
+     * @return bool True if RentalEventType is set.
      */
     public function isSetRentalEventType()
     {
@@ -178,7 +178,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ExtensionLength is set.
      *
-     * @return true if ExtensionLength is set.
+     * @return bool True if ExtensionLength is set.
      */
     public function isSetExtensionLength()
     {
@@ -224,7 +224,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PostedDate is set.
      *
-     * @return true if PostedDate is set.
+     * @return bool True if PostedDate is set.
      */
     public function isSetPostedDate()
     {
@@ -285,7 +285,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RentalChargeList is set.
      *
-     * @return true if RentalChargeList is set.
+     * @return bool True if RentalChargeList is set.
      */
     public function isSetRentalChargeList()
     {
@@ -349,7 +349,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RentalFeeList is set.
      *
-     * @return true if RentalFeeList is set.
+     * @return bool True if RentalFeeList is set.
      */
     public function isSetRentalFeeList()
     {
@@ -398,7 +398,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceName is set.
      *
-     * @return true if MarketplaceName is set.
+     * @return bool True if MarketplaceName is set.
      */
     public function isSetMarketplaceName()
     {
@@ -444,7 +444,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RentalInitialValue is set.
      *
-     * @return true if RentalInitialValue is set.
+     * @return bool True if RentalInitialValue is set.
      */
     public function isSetRentalInitialValue()
     {
@@ -490,7 +490,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RentalReimbursement is set.
      *
-     * @return true if RentalReimbursement is set.
+     * @return bool True if RentalReimbursement is set.
      */
     public function isSetRentalReimbursement()
     {

--- a/src/MWSFinancesService/Model/ResponseMetadata.php
+++ b/src/MWSFinancesService/Model/ResponseMetadata.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RequestId is set.
      *
-     * @return true if RequestId is set.
+     * @return bool True if RequestId is set.
      */
     public function isSetRequestId()
     {

--- a/src/MWSFinancesService/Model/RetrochargeEvent.php
+++ b/src/MWSFinancesService/Model/RetrochargeEvent.php
@@ -80,7 +80,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RetrochargeEventType is set.
      *
-     * @return true if RetrochargeEventType is set.
+     * @return bool True if RetrochargeEventType is set.
      */
     public function isSetRetrochargeEventType()
     {
@@ -126,7 +126,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {
@@ -172,7 +172,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PostedDate is set.
      *
-     * @return true if PostedDate is set.
+     * @return bool True if PostedDate is set.
      */
     public function isSetPostedDate()
     {
@@ -218,7 +218,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if BaseTax is set.
      *
-     * @return true if BaseTax is set.
+     * @return bool True if BaseTax is set.
      */
     public function isSetBaseTax()
     {
@@ -264,7 +264,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShippingTax is set.
      *
-     * @return true if ShippingTax is set.
+     * @return bool True if ShippingTax is set.
      */
     public function isSetShippingTax()
     {
@@ -310,7 +310,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceName is set.
      *
-     * @return true if MarketplaceName is set.
+     * @return bool True if MarketplaceName is set.
      */
     public function isSetMarketplaceName()
     {

--- a/src/MWSFinancesService/Model/ServiceFeeEvent.php
+++ b/src/MWSFinancesService/Model/ServiceFeeEvent.php
@@ -82,7 +82,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {
@@ -128,7 +128,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FeeReason is set.
      *
-     * @return true if FeeReason is set.
+     * @return bool True if FeeReason is set.
      */
     public function isSetFeeReason()
     {
@@ -189,7 +189,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FeeList is set.
      *
-     * @return true if FeeList is set.
+     * @return bool True if FeeList is set.
      */
     public function isSetFeeList()
     {
@@ -238,7 +238,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -284,7 +284,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FnSKU is set.
      *
-     * @return true if FnSKU is set.
+     * @return bool True if FnSKU is set.
      */
     public function isSetFnSKU()
     {
@@ -330,7 +330,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FeeDescription is set.
      *
-     * @return true if FeeDescription is set.
+     * @return bool True if FeeDescription is set.
      */
     public function isSetFeeDescription()
     {
@@ -376,7 +376,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {

--- a/src/MWSFinancesService/Model/ShipmentEvent.php
+++ b/src/MWSFinancesService/Model/ShipmentEvent.php
@@ -94,7 +94,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {
@@ -140,7 +140,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerOrderId is set.
      *
-     * @return true if SellerOrderId is set.
+     * @return bool True if SellerOrderId is set.
      */
     public function isSetSellerOrderId()
     {
@@ -186,7 +186,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceName is set.
      *
-     * @return true if MarketplaceName is set.
+     * @return bool True if MarketplaceName is set.
      */
     public function isSetMarketplaceName()
     {
@@ -247,7 +247,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if OrderChargeList is set.
      *
-     * @return true if OrderChargeList is set.
+     * @return bool True if OrderChargeList is set.
      */
     public function isSetOrderChargeList()
     {
@@ -311,7 +311,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if OrderChargeAdjustmentList is set.
      *
-     * @return true if OrderChargeAdjustmentList is set.
+     * @return bool True if OrderChargeAdjustmentList is set.
      */
     public function isSetOrderChargeAdjustmentList()
     {
@@ -375,7 +375,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipmentFeeList is set.
      *
-     * @return true if ShipmentFeeList is set.
+     * @return bool True if ShipmentFeeList is set.
      */
     public function isSetShipmentFeeList()
     {
@@ -439,7 +439,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipmentFeeAdjustmentList is set.
      *
-     * @return true if ShipmentFeeAdjustmentList is set.
+     * @return bool True if ShipmentFeeAdjustmentList is set.
      */
     public function isSetShipmentFeeAdjustmentList()
     {
@@ -503,7 +503,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if OrderFeeList is set.
      *
-     * @return true if OrderFeeList is set.
+     * @return bool True if OrderFeeList is set.
      */
     public function isSetOrderFeeList()
     {
@@ -567,7 +567,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if OrderFeeAdjustmentList is set.
      *
-     * @return true if OrderFeeAdjustmentList is set.
+     * @return bool True if OrderFeeAdjustmentList is set.
      */
     public function isSetOrderFeeAdjustmentList()
     {
@@ -631,7 +631,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DirectPaymentList is set.
      *
-     * @return true if DirectPaymentList is set.
+     * @return bool True if DirectPaymentList is set.
      */
     public function isSetDirectPaymentList()
     {
@@ -680,7 +680,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PostedDate is set.
      *
-     * @return true if PostedDate is set.
+     * @return bool True if PostedDate is set.
      */
     public function isSetPostedDate()
     {
@@ -741,7 +741,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipmentItemList is set.
      *
-     * @return true if ShipmentItemList is set.
+     * @return bool True if ShipmentItemList is set.
      */
     public function isSetShipmentItemList()
     {
@@ -805,7 +805,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipmentItemAdjustmentList is set.
      *
-     * @return true if ShipmentItemAdjustmentList is set.
+     * @return bool True if ShipmentItemAdjustmentList is set.
      */
     public function isSetShipmentItemAdjustmentList()
     {

--- a/src/MWSFinancesService/Model/ShipmentItem.php
+++ b/src/MWSFinancesService/Model/ShipmentItem.php
@@ -92,7 +92,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -138,7 +138,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if OrderItemId is set.
      *
-     * @return true if OrderItemId is set.
+     * @return bool True if OrderItemId is set.
      */
     public function isSetOrderItemId()
     {
@@ -184,7 +184,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if OrderAdjustmentItemId is set.
      *
-     * @return true if OrderAdjustmentItemId is set.
+     * @return bool True if OrderAdjustmentItemId is set.
      */
     public function isSetOrderAdjustmentItemId()
     {
@@ -230,7 +230,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if QuantityShipped is set.
      *
-     * @return true if QuantityShipped is set.
+     * @return bool True if QuantityShipped is set.
      */
     public function isSetQuantityShipped()
     {
@@ -291,7 +291,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemChargeList is set.
      *
-     * @return true if ItemChargeList is set.
+     * @return bool True if ItemChargeList is set.
      */
     public function isSetItemChargeList()
     {
@@ -355,7 +355,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemChargeAdjustmentList is set.
      *
-     * @return true if ItemChargeAdjustmentList is set.
+     * @return bool True if ItemChargeAdjustmentList is set.
      */
     public function isSetItemChargeAdjustmentList()
     {
@@ -419,7 +419,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemFeeList is set.
      *
-     * @return true if ItemFeeList is set.
+     * @return bool True if ItemFeeList is set.
      */
     public function isSetItemFeeList()
     {
@@ -483,7 +483,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemFeeAdjustmentList is set.
      *
-     * @return true if ItemFeeAdjustmentList is set.
+     * @return bool True if ItemFeeAdjustmentList is set.
      */
     public function isSetItemFeeAdjustmentList()
     {
@@ -547,7 +547,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PromotionList is set.
      *
-     * @return true if PromotionList is set.
+     * @return bool True if PromotionList is set.
      */
     public function isSetPromotionList()
     {
@@ -611,7 +611,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PromotionAdjustmentList is set.
      *
-     * @return true if PromotionAdjustmentList is set.
+     * @return bool True if PromotionAdjustmentList is set.
      */
     public function isSetPromotionAdjustmentList()
     {
@@ -660,7 +660,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CostOfPointsGranted is set.
      *
-     * @return true if CostOfPointsGranted is set.
+     * @return bool True if CostOfPointsGranted is set.
      */
     public function isSetCostOfPointsGranted()
     {
@@ -706,7 +706,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CostOfPointsReturned is set.
      *
-     * @return true if CostOfPointsReturned is set.
+     * @return bool True if CostOfPointsReturned is set.
      */
     public function isSetCostOfPointsReturned()
     {

--- a/src/MWSFinancesService/Model/SolutionProviderCreditEvent.php
+++ b/src/MWSFinancesService/Model/SolutionProviderCreditEvent.php
@@ -84,7 +84,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ProviderTransactionType is set.
      *
-     * @return true if ProviderTransactionType is set.
+     * @return bool True if ProviderTransactionType is set.
      */
     public function isSetProviderTransactionType()
     {
@@ -130,7 +130,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerOrderId is set.
      *
-     * @return true if SellerOrderId is set.
+     * @return bool True if SellerOrderId is set.
      */
     public function isSetSellerOrderId()
     {
@@ -176,7 +176,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -222,7 +222,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceCountryCode is set.
      *
-     * @return true if MarketplaceCountryCode is set.
+     * @return bool True if MarketplaceCountryCode is set.
      */
     public function isSetMarketplaceCountryCode()
     {
@@ -268,7 +268,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -314,7 +314,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerStoreName is set.
      *
-     * @return true if SellerStoreName is set.
+     * @return bool True if SellerStoreName is set.
      */
     public function isSetSellerStoreName()
     {
@@ -360,7 +360,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ProviderId is set.
      *
-     * @return true if ProviderId is set.
+     * @return bool True if ProviderId is set.
      */
     public function isSetProviderId()
     {
@@ -406,7 +406,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ProviderStoreName is set.
      *
-     * @return true if ProviderStoreName is set.
+     * @return bool True if ProviderStoreName is set.
      */
     public function isSetProviderStoreName()
     {

--- a/src/MWSMerchantFulfillmentService/Model.php
+++ b/src/MWSMerchantFulfillmentService/Model.php
@@ -406,7 +406,7 @@ abstract class MWSMerchantFulfillmentService_Model
     * Checks  whether passed variable is an associative array
     *
     * @param mixed $var
-    * @return TRUE if passed variable is an associative array
+    * @return bool True if passed variable is an associative array
     */
     private function _isAssociativeArray($var)
     {
@@ -417,7 +417,7 @@ abstract class MWSMerchantFulfillmentService_Model
     * Checks  whether passed variable is DOMElement
     *
     * @param mixed $var
-    * @return TRUE if passed variable is DOMElement
+    * @return bool True if passed variable is DOMElement
     */
     private function _isDOMElement($var)
     {
@@ -428,7 +428,7 @@ abstract class MWSMerchantFulfillmentService_Model
     * Checks  whether passed variable is numeric array
     *
     * @param mixed $var
-    * @return TRUE if passed variable is an numeric array
+    * @return bool True if passed variable is an numeric array
     */
     protected function _isNumericArray($var)
     {

--- a/src/MWSMerchantFulfillmentService/Model/Address.php
+++ b/src/MWSMerchantFulfillmentService/Model/Address.php
@@ -90,7 +90,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Name is set.
      *
-     * @return true if Name is set.
+     * @return bool True if Name is set.
      */
     public function isSetName()
     {
@@ -136,7 +136,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AddressLine1 is set.
      *
-     * @return true if AddressLine1 is set.
+     * @return bool True if AddressLine1 is set.
      */
     public function isSetAddressLine1()
     {
@@ -182,7 +182,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AddressLine2 is set.
      *
-     * @return true if AddressLine2 is set.
+     * @return bool True if AddressLine2 is set.
      */
     public function isSetAddressLine2()
     {
@@ -228,7 +228,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AddressLine3 is set.
      *
-     * @return true if AddressLine3 is set.
+     * @return bool True if AddressLine3 is set.
      */
     public function isSetAddressLine3()
     {
@@ -274,7 +274,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DistrictOrCounty is set.
      *
-     * @return true if DistrictOrCounty is set.
+     * @return bool True if DistrictOrCounty is set.
      */
     public function isSetDistrictOrCounty()
     {
@@ -320,7 +320,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Email is set.
      *
-     * @return true if Email is set.
+     * @return bool True if Email is set.
      */
     public function isSetEmail()
     {
@@ -366,7 +366,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if City is set.
      *
-     * @return true if City is set.
+     * @return bool True if City is set.
      */
     public function isSetCity()
     {
@@ -412,7 +412,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if StateOrProvinceCode is set.
      *
-     * @return true if StateOrProvinceCode is set.
+     * @return bool True if StateOrProvinceCode is set.
      */
     public function isSetStateOrProvinceCode()
     {
@@ -458,7 +458,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PostalCode is set.
      *
-     * @return true if PostalCode is set.
+     * @return bool True if PostalCode is set.
      */
     public function isSetPostalCode()
     {
@@ -504,7 +504,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CountryCode is set.
      *
-     * @return true if CountryCode is set.
+     * @return bool True if CountryCode is set.
      */
     public function isSetCountryCode()
     {
@@ -550,7 +550,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Phone is set.
      *
-     * @return true if Phone is set.
+     * @return bool True if Phone is set.
      */
     public function isSetPhone()
     {

--- a/src/MWSMerchantFulfillmentService/Model/CancelShipmentRequest.php
+++ b/src/MWSMerchantFulfillmentService/Model/CancelShipmentRequest.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {

--- a/src/MWSMerchantFulfillmentService/Model/CancelShipmentResponse.php
+++ b/src/MWSMerchantFulfillmentService/Model/CancelShipmentResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CancelShipmentResult is set.
      *
-     * @return true if CancelShipmentResult is set.
+     * @return bool True if CancelShipmentResult is set.
      */
     public function isSetCancelShipmentResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSMerchantFulfillmentService/Model/CancelShipmentResult.php
+++ b/src/MWSMerchantFulfillmentService/Model/CancelShipmentResult.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Shipment is set.
      *
-     * @return true if Shipment is set.
+     * @return bool True if Shipment is set.
      */
     public function isSetShipment()
     {

--- a/src/MWSMerchantFulfillmentService/Model/CreateShipmentRequest.php
+++ b/src/MWSMerchantFulfillmentService/Model/CreateShipmentRequest.php
@@ -78,7 +78,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -124,7 +124,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -170,7 +170,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipmentRequestDetails is set.
      *
-     * @return true if ShipmentRequestDetails is set.
+     * @return bool True if ShipmentRequestDetails is set.
      */
     public function isSetShipmentRequestDetails()
     {
@@ -216,7 +216,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShippingServiceId is set.
      *
-     * @return true if ShippingServiceId is set.
+     * @return bool True if ShippingServiceId is set.
      */
     public function isSetShippingServiceId()
     {
@@ -262,7 +262,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShippingServiceOfferId is set.
      *
-     * @return true if ShippingServiceOfferId is set.
+     * @return bool True if ShippingServiceOfferId is set.
      */
     public function isSetShippingServiceOfferId()
     {

--- a/src/MWSMerchantFulfillmentService/Model/CreateShipmentResponse.php
+++ b/src/MWSMerchantFulfillmentService/Model/CreateShipmentResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CreateShipmentResult is set.
      *
-     * @return true if CreateShipmentResult is set.
+     * @return bool True if CreateShipmentResult is set.
      */
     public function isSetCreateShipmentResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSMerchantFulfillmentService/Model/CreateShipmentResult.php
+++ b/src/MWSMerchantFulfillmentService/Model/CreateShipmentResult.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Shipment is set.
      *
-     * @return true if Shipment is set.
+     * @return bool True if Shipment is set.
      */
     public function isSetShipment()
     {

--- a/src/MWSMerchantFulfillmentService/Model/CurrencyAmount.php
+++ b/src/MWSMerchantFulfillmentService/Model/CurrencyAmount.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CurrencyCode is set.
      *
-     * @return true if CurrencyCode is set.
+     * @return bool True if CurrencyCode is set.
      */
     public function isSetCurrencyCode()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Amount is set.
      *
-     * @return true if Amount is set.
+     * @return bool True if Amount is set.
      */
     public function isSetAmount()
     {

--- a/src/MWSMerchantFulfillmentService/Model/FileContents.php
+++ b/src/MWSMerchantFulfillmentService/Model/FileContents.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Contents is set.
      *
-     * @return true if Contents is set.
+     * @return bool True if Contents is set.
      */
     public function isSetContents()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FileType is set.
      *
-     * @return true if FileType is set.
+     * @return bool True if FileType is set.
      */
     public function isSetFileType()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Checksum is set.
      *
-     * @return true if Checksum is set.
+     * @return bool True if Checksum is set.
      */
     public function isSetChecksum()
     {

--- a/src/MWSMerchantFulfillmentService/Model/GetEligibleShippingServicesRequest.php
+++ b/src/MWSMerchantFulfillmentService/Model/GetEligibleShippingServicesRequest.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipmentRequestDetails is set.
      *
-     * @return true if ShipmentRequestDetails is set.
+     * @return bool True if ShipmentRequestDetails is set.
      */
     public function isSetShipmentRequestDetails()
     {

--- a/src/MWSMerchantFulfillmentService/Model/GetEligibleShippingServicesResponse.php
+++ b/src/MWSMerchantFulfillmentService/Model/GetEligibleShippingServicesResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GetEligibleShippingServicesResult is set.
      *
-     * @return true if GetEligibleShippingServicesResult is set.
+     * @return bool True if GetEligibleShippingServicesResult is set.
      */
     public function isSetGetEligibleShippingServicesResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSMerchantFulfillmentService/Model/GetEligibleShippingServicesResult.php
+++ b/src/MWSMerchantFulfillmentService/Model/GetEligibleShippingServicesResult.php
@@ -89,7 +89,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShippingServiceList is set.
      *
-     * @return true if ShippingServiceList is set.
+     * @return bool True if ShippingServiceList is set.
      */
     public function isSetShippingServiceList()
     {
@@ -153,7 +153,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if TemporarilyUnavailableCarrierList is set.
      *
-     * @return true if TemporarilyUnavailableCarrierList is set.
+     * @return bool True if TemporarilyUnavailableCarrierList is set.
      */
     public function isSetTemporarilyUnavailableCarrierList()
     {
@@ -217,7 +217,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if TermsAndConditionsNotAcceptedCarrierList is set.
      *
-     * @return true if TermsAndConditionsNotAcceptedCarrierList is set.
+     * @return bool True if TermsAndConditionsNotAcceptedCarrierList is set.
      */
     public function isSetTermsAndConditionsNotAcceptedCarrierList()
     {

--- a/src/MWSMerchantFulfillmentService/Model/GetServiceStatusRequest.php
+++ b/src/MWSMerchantFulfillmentService/Model/GetServiceStatusRequest.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {

--- a/src/MWSMerchantFulfillmentService/Model/GetServiceStatusResponse.php
+++ b/src/MWSMerchantFulfillmentService/Model/GetServiceStatusResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GetServiceStatusResult is set.
      *
-     * @return true if GetServiceStatusResult is set.
+     * @return bool True if GetServiceStatusResult is set.
      */
     public function isSetGetServiceStatusResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSMerchantFulfillmentService/Model/GetServiceStatusResult.php
+++ b/src/MWSMerchantFulfillmentService/Model/GetServiceStatusResult.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Status is set.
      *
-     * @return true if Status is set.
+     * @return bool True if Status is set.
      */
     public function isSetStatus()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Timestamp is set.
      *
-     * @return true if Timestamp is set.
+     * @return bool True if Timestamp is set.
      */
     public function isSetTimestamp()
     {

--- a/src/MWSMerchantFulfillmentService/Model/GetShipmentRequest.php
+++ b/src/MWSMerchantFulfillmentService/Model/GetShipmentRequest.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {

--- a/src/MWSMerchantFulfillmentService/Model/GetShipmentResponse.php
+++ b/src/MWSMerchantFulfillmentService/Model/GetShipmentResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GetShipmentResult is set.
      *
-     * @return true if GetShipmentResult is set.
+     * @return bool True if GetShipmentResult is set.
      */
     public function isSetGetShipmentResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSMerchantFulfillmentService/Model/GetShipmentResult.php
+++ b/src/MWSMerchantFulfillmentService/Model/GetShipmentResult.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Shipment is set.
      *
-     * @return true if Shipment is set.
+     * @return bool True if Shipment is set.
      */
     public function isSetShipment()
     {

--- a/src/MWSMerchantFulfillmentService/Model/Item.php
+++ b/src/MWSMerchantFulfillmentService/Model/Item.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if OrderItemId is set.
      *
-     * @return true if OrderItemId is set.
+     * @return bool True if OrderItemId is set.
      */
     public function isSetOrderItemId()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Quantity is set.
      *
-     * @return true if Quantity is set.
+     * @return bool True if Quantity is set.
      */
     public function isSetQuantity()
     {

--- a/src/MWSMerchantFulfillmentService/Model/Label.php
+++ b/src/MWSMerchantFulfillmentService/Model/Label.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Dimensions is set.
      *
-     * @return true if Dimensions is set.
+     * @return bool True if Dimensions is set.
      */
     public function isSetDimensions()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FileContents is set.
      *
-     * @return true if FileContents is set.
+     * @return bool True if FileContents is set.
      */
     public function isSetFileContents()
     {

--- a/src/MWSMerchantFulfillmentService/Model/LabelDimensions.php
+++ b/src/MWSMerchantFulfillmentService/Model/LabelDimensions.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Length is set.
      *
-     * @return true if Length is set.
+     * @return bool True if Length is set.
      */
     public function isSetLength()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Width is set.
      *
-     * @return true if Width is set.
+     * @return bool True if Width is set.
      */
     public function isSetWidth()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Unit is set.
      *
-     * @return true if Unit is set.
+     * @return bool True if Unit is set.
      */
     public function isSetUnit()
     {

--- a/src/MWSMerchantFulfillmentService/Model/PackageDimensions.php
+++ b/src/MWSMerchantFulfillmentService/Model/PackageDimensions.php
@@ -78,7 +78,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Length is set.
      *
-     * @return true if Length is set.
+     * @return bool True if Length is set.
      */
     public function isSetLength()
     {
@@ -124,7 +124,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Width is set.
      *
-     * @return true if Width is set.
+     * @return bool True if Width is set.
      */
     public function isSetWidth()
     {
@@ -170,7 +170,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Height is set.
      *
-     * @return true if Height is set.
+     * @return bool True if Height is set.
      */
     public function isSetHeight()
     {
@@ -216,7 +216,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Unit is set.
      *
-     * @return true if Unit is set.
+     * @return bool True if Unit is set.
      */
     public function isSetUnit()
     {
@@ -262,7 +262,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PredefinedPackageDimensions is set.
      *
-     * @return true if PredefinedPackageDimensions is set.
+     * @return bool True if PredefinedPackageDimensions is set.
      */
     public function isSetPredefinedPackageDimensions()
     {

--- a/src/MWSMerchantFulfillmentService/Model/ResponseMetadata.php
+++ b/src/MWSMerchantFulfillmentService/Model/ResponseMetadata.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RequestId is set.
      *
-     * @return true if RequestId is set.
+     * @return bool True if RequestId is set.
      */
     public function isSetRequestId()
     {

--- a/src/MWSMerchantFulfillmentService/Model/Shipment.php
+++ b/src/MWSMerchantFulfillmentService/Model/Shipment.php
@@ -98,7 +98,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipmentId is set.
      *
-     * @return true if ShipmentId is set.
+     * @return bool True if ShipmentId is set.
      */
     public function isSetShipmentId()
     {
@@ -144,7 +144,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {
@@ -190,7 +190,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerOrderId is set.
      *
-     * @return true if SellerOrderId is set.
+     * @return bool True if SellerOrderId is set.
      */
     public function isSetSellerOrderId()
     {
@@ -251,7 +251,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemList is set.
      *
-     * @return true if ItemList is set.
+     * @return bool True if ItemList is set.
      */
     public function isSetItemList()
     {
@@ -300,7 +300,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipFromAddress is set.
      *
-     * @return true if ShipFromAddress is set.
+     * @return bool True if ShipFromAddress is set.
      */
     public function isSetShipFromAddress()
     {
@@ -346,7 +346,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipToAddress is set.
      *
-     * @return true if ShipToAddress is set.
+     * @return bool True if ShipToAddress is set.
      */
     public function isSetShipToAddress()
     {
@@ -392,7 +392,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PackageDimensions is set.
      *
-     * @return true if PackageDimensions is set.
+     * @return bool True if PackageDimensions is set.
      */
     public function isSetPackageDimensions()
     {
@@ -438,7 +438,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Weight is set.
      *
-     * @return true if Weight is set.
+     * @return bool True if Weight is set.
      */
     public function isSetWeight()
     {
@@ -484,7 +484,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Insurance is set.
      *
-     * @return true if Insurance is set.
+     * @return bool True if Insurance is set.
      */
     public function isSetInsurance()
     {
@@ -530,7 +530,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShippingService is set.
      *
-     * @return true if ShippingService is set.
+     * @return bool True if ShippingService is set.
      */
     public function isSetShippingService()
     {
@@ -576,7 +576,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Label is set.
      *
-     * @return true if Label is set.
+     * @return bool True if Label is set.
      */
     public function isSetLabel()
     {
@@ -622,7 +622,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Status is set.
      *
-     * @return true if Status is set.
+     * @return bool True if Status is set.
      */
     public function isSetStatus()
     {
@@ -668,7 +668,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if TrackingId is set.
      *
-     * @return true if TrackingId is set.
+     * @return bool True if TrackingId is set.
      */
     public function isSetTrackingId()
     {
@@ -714,7 +714,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CreatedDate is set.
      *
-     * @return true if CreatedDate is set.
+     * @return bool True if CreatedDate is set.
      */
     public function isSetCreatedDate()
     {
@@ -760,7 +760,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LastUpdatedDate is set.
      *
-     * @return true if LastUpdatedDate is set.
+     * @return bool True if LastUpdatedDate is set.
      */
     public function isSetLastUpdatedDate()
     {

--- a/src/MWSMerchantFulfillmentService/Model/ShipmentRequestDetails.php
+++ b/src/MWSMerchantFulfillmentService/Model/ShipmentRequestDetails.php
@@ -86,7 +86,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {
@@ -132,7 +132,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerOrderId is set.
      *
-     * @return true if SellerOrderId is set.
+     * @return bool True if SellerOrderId is set.
      */
     public function isSetSellerOrderId()
     {
@@ -193,7 +193,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemList is set.
      *
-     * @return true if ItemList is set.
+     * @return bool True if ItemList is set.
      */
     public function isSetItemList()
     {
@@ -242,7 +242,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipFromAddress is set.
      *
-     * @return true if ShipFromAddress is set.
+     * @return bool True if ShipFromAddress is set.
      */
     public function isSetShipFromAddress()
     {
@@ -288,7 +288,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PackageDimensions is set.
      *
-     * @return true if PackageDimensions is set.
+     * @return bool True if PackageDimensions is set.
      */
     public function isSetPackageDimensions()
     {
@@ -334,7 +334,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Weight is set.
      *
-     * @return true if Weight is set.
+     * @return bool True if Weight is set.
      */
     public function isSetWeight()
     {
@@ -380,7 +380,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MustArriveByDate is set.
      *
-     * @return true if MustArriveByDate is set.
+     * @return bool True if MustArriveByDate is set.
      */
     public function isSetMustArriveByDate()
     {
@@ -426,7 +426,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipDate is set.
      *
-     * @return true if ShipDate is set.
+     * @return bool True if ShipDate is set.
      */
     public function isSetShipDate()
     {
@@ -472,7 +472,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShippingServiceOptions is set.
      *
-     * @return true if ShippingServiceOptions is set.
+     * @return bool True if ShippingServiceOptions is set.
      */
     public function isSetShippingServiceOptions()
     {

--- a/src/MWSMerchantFulfillmentService/Model/ShippingService.php
+++ b/src/MWSMerchantFulfillmentService/Model/ShippingService.php
@@ -86,7 +86,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShippingServiceName is set.
      *
-     * @return true if ShippingServiceName is set.
+     * @return bool True if ShippingServiceName is set.
      */
     public function isSetShippingServiceName()
     {
@@ -132,7 +132,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CarrierName is set.
      *
-     * @return true if CarrierName is set.
+     * @return bool True if CarrierName is set.
      */
     public function isSetCarrierName()
     {
@@ -178,7 +178,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShippingServiceId is set.
      *
-     * @return true if ShippingServiceId is set.
+     * @return bool True if ShippingServiceId is set.
      */
     public function isSetShippingServiceId()
     {
@@ -224,7 +224,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShippingServiceOfferId is set.
      *
-     * @return true if ShippingServiceOfferId is set.
+     * @return bool True if ShippingServiceOfferId is set.
      */
     public function isSetShippingServiceOfferId()
     {
@@ -270,7 +270,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShipDate is set.
      *
-     * @return true if ShipDate is set.
+     * @return bool True if ShipDate is set.
      */
     public function isSetShipDate()
     {
@@ -316,7 +316,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if EarliestEstimatedDeliveryDate is set.
      *
-     * @return true if EarliestEstimatedDeliveryDate is set.
+     * @return bool True if EarliestEstimatedDeliveryDate is set.
      */
     public function isSetEarliestEstimatedDeliveryDate()
     {
@@ -362,7 +362,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LatestEstimatedDeliveryDate is set.
      *
-     * @return true if LatestEstimatedDeliveryDate is set.
+     * @return bool True if LatestEstimatedDeliveryDate is set.
      */
     public function isSetLatestEstimatedDeliveryDate()
     {
@@ -408,7 +408,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Rate is set.
      *
-     * @return true if Rate is set.
+     * @return bool True if Rate is set.
      */
     public function isSetRate()
     {
@@ -454,7 +454,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ShippingServiceOptions is set.
      *
-     * @return true if ShippingServiceOptions is set.
+     * @return bool True if ShippingServiceOptions is set.
      */
     public function isSetShippingServiceOptions()
     {

--- a/src/MWSMerchantFulfillmentService/Model/ShippingServiceOptions.php
+++ b/src/MWSMerchantFulfillmentService/Model/ShippingServiceOptions.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DeliveryExperience is set.
      *
-     * @return true if DeliveryExperience is set.
+     * @return bool True if DeliveryExperience is set.
      */
     public function isSetDeliveryExperience()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DeclaredValue is set.
      *
-     * @return true if DeclaredValue is set.
+     * @return bool True if DeclaredValue is set.
      */
     public function isSetDeclaredValue()
     {
@@ -144,7 +144,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check the value of CarrierWillPickUp.
      *
-     * @return true if CarrierWillPickUp is set to true.
+     * @return bool True if CarrierWillPickUp is set to true.
      */
     public function isCarrierWillPickUp()
     {
@@ -176,7 +176,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CarrierWillPickUp is set.
      *
-     * @return true if CarrierWillPickUp is set.
+     * @return bool True if CarrierWillPickUp is set.
      */
     public function isSetCarrierWillPickUp()
     {

--- a/src/MWSMerchantFulfillmentService/Model/TemporarilyUnavailableCarrier.php
+++ b/src/MWSMerchantFulfillmentService/Model/TemporarilyUnavailableCarrier.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CarrierName is set.
      *
-     * @return true if CarrierName is set.
+     * @return bool True if CarrierName is set.
      */
     public function isSetCarrierName()
     {

--- a/src/MWSMerchantFulfillmentService/Model/TermsAndConditionsNotAcceptedCarrier.php
+++ b/src/MWSMerchantFulfillmentService/Model/TermsAndConditionsNotAcceptedCarrier.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CarrierName is set.
      *
-     * @return true if CarrierName is set.
+     * @return bool True if CarrierName is set.
      */
     public function isSetCarrierName()
     {

--- a/src/MWSMerchantFulfillmentService/Model/Weight.php
+++ b/src/MWSMerchantFulfillmentService/Model/Weight.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Value is set.
      *
-     * @return true if Value is set.
+     * @return bool True if Value is set.
      */
     public function isSetValue()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Unit is set.
      *
-     * @return true if Unit is set.
+     * @return bool True if Unit is set.
      */
     public function isSetUnit()
     {

--- a/src/MWSRecommendationsSectionService/Model.php
+++ b/src/MWSRecommendationsSectionService/Model.php
@@ -400,7 +400,7 @@ abstract class MWSRecommendationsSectionService_Model
     * Checks  whether passed variable is an associative array
     *
     * @param mixed $var
-    * @return TRUE if passed variable is an associative array
+    * @return bool True if passed variable is an associative array
     */
     private function _isAssociativeArray($var)
     {
@@ -411,7 +411,7 @@ abstract class MWSRecommendationsSectionService_Model
     * Checks  whether passed variable is DOMElement
     *
     * @param mixed $var
-    * @return TRUE if passed variable is DOMElement
+    * @return bool True if passed variable is DOMElement
     */
     private function _isDOMElement($var)
     {
@@ -422,7 +422,7 @@ abstract class MWSRecommendationsSectionService_Model
     * Checks  whether passed variable is numeric array
     *
     * @param mixed $var
-    * @return TRUE if passed variable is an numeric array
+    * @return bool True if passed variable is an numeric array
     */
     protected function _isNumericArray($var)
     {

--- a/src/MWSRecommendationsSectionService/Model/AdvertisingRecommendation.php
+++ b/src/MWSRecommendationsSectionService/Model/AdvertisingRecommendation.php
@@ -92,7 +92,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LastUpdated is set.
      *
-     * @return true if LastUpdated is set.
+     * @return bool True if LastUpdated is set.
      */
     public function isSetLastUpdated()
     {
@@ -138,7 +138,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemIdentifier is set.
      *
-     * @return true if ItemIdentifier is set.
+     * @return bool True if ItemIdentifier is set.
      */
     public function isSetItemIdentifier()
     {
@@ -184,7 +184,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemName is set.
      *
-     * @return true if ItemName is set.
+     * @return bool True if ItemName is set.
      */
     public function isSetItemName()
     {
@@ -230,7 +230,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if BrandName is set.
      *
-     * @return true if BrandName is set.
+     * @return bool True if BrandName is set.
      */
     public function isSetBrandName()
     {
@@ -276,7 +276,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ProductCategory is set.
      *
-     * @return true if ProductCategory is set.
+     * @return bool True if ProductCategory is set.
      */
     public function isSetProductCategory()
     {
@@ -322,7 +322,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SalesRank is set.
      *
-     * @return true if SalesRank is set.
+     * @return bool True if SalesRank is set.
      */
     public function isSetSalesRank()
     {
@@ -368,7 +368,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if YourPricePlusShipping is set.
      *
-     * @return true if YourPricePlusShipping is set.
+     * @return bool True if YourPricePlusShipping is set.
      */
     public function isSetYourPricePlusShipping()
     {
@@ -414,7 +414,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LowestPricePlusShipping is set.
      *
-     * @return true if LowestPricePlusShipping is set.
+     * @return bool True if LowestPricePlusShipping is set.
      */
     public function isSetLowestPricePlusShipping()
     {
@@ -460,7 +460,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AvailableQuantity is set.
      *
-     * @return true if AvailableQuantity is set.
+     * @return bool True if AvailableQuantity is set.
      */
     public function isSetAvailableQuantity()
     {
@@ -506,7 +506,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SalesForTheLast30Days is set.
      *
-     * @return true if SalesForTheLast30Days is set.
+     * @return bool True if SalesForTheLast30Days is set.
      */
     public function isSetSalesForTheLast30Days()
     {
@@ -552,7 +552,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationId is set.
      *
-     * @return true if RecommendationId is set.
+     * @return bool True if RecommendationId is set.
      */
     public function isSetRecommendationId()
     {
@@ -598,7 +598,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationReason is set.
      *
-     * @return true if RecommendationReason is set.
+     * @return bool True if RecommendationReason is set.
      */
     public function isSetRecommendationReason()
     {

--- a/src/MWSRecommendationsSectionService/Model/CategoryQuery.php
+++ b/src/MWSRecommendationsSectionService/Model/CategoryQuery.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationCategory is set.
      *
-     * @return true if RecommendationCategory is set.
+     * @return bool True if RecommendationCategory is set.
      */
     public function isSetRecommendationCategory()
     {
@@ -133,7 +133,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FilterOptions is set.
      *
-     * @return true if FilterOptions is set.
+     * @return bool True if FilterOptions is set.
      */
     public function isSetFilterOptions()
     {

--- a/src/MWSRecommendationsSectionService/Model/DimensionMeasure.php
+++ b/src/MWSRecommendationsSectionService/Model/DimensionMeasure.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Value is set.
      *
-     * @return true if Value is set.
+     * @return bool True if Value is set.
      */
     public function isSetValue()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Unit is set.
      *
-     * @return true if Unit is set.
+     * @return bool True if Unit is set.
      */
     public function isSetUnit()
     {

--- a/src/MWSRecommendationsSectionService/Model/FulfillmentRecommendation.php
+++ b/src/MWSRecommendationsSectionService/Model/FulfillmentRecommendation.php
@@ -96,7 +96,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LastUpdated is set.
      *
-     * @return true if LastUpdated is set.
+     * @return bool True if LastUpdated is set.
      */
     public function isSetLastUpdated()
     {
@@ -142,7 +142,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemIdentifier is set.
      *
-     * @return true if ItemIdentifier is set.
+     * @return bool True if ItemIdentifier is set.
      */
     public function isSetItemIdentifier()
     {
@@ -188,7 +188,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemName is set.
      *
-     * @return true if ItemName is set.
+     * @return bool True if ItemName is set.
      */
     public function isSetItemName()
     {
@@ -234,7 +234,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if BrandName is set.
      *
-     * @return true if BrandName is set.
+     * @return bool True if BrandName is set.
      */
     public function isSetBrandName()
     {
@@ -280,7 +280,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ProductCategory is set.
      *
-     * @return true if ProductCategory is set.
+     * @return bool True if ProductCategory is set.
      */
     public function isSetProductCategory()
     {
@@ -326,7 +326,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SalesRank is set.
      *
-     * @return true if SalesRank is set.
+     * @return bool True if SalesRank is set.
      */
     public function isSetSalesRank()
     {
@@ -372,7 +372,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if BuyboxPrice is set.
      *
-     * @return true if BuyboxPrice is set.
+     * @return bool True if BuyboxPrice is set.
      */
     public function isSetBuyboxPrice()
     {
@@ -418,7 +418,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NumberOfOffers is set.
      *
-     * @return true if NumberOfOffers is set.
+     * @return bool True if NumberOfOffers is set.
      */
     public function isSetNumberOfOffers()
     {
@@ -464,7 +464,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NumberOfOffersFulfilledByAmazon is set.
      *
-     * @return true if NumberOfOffersFulfilledByAmazon is set.
+     * @return bool True if NumberOfOffersFulfilledByAmazon is set.
      */
     public function isSetNumberOfOffersFulfilledByAmazon()
     {
@@ -510,7 +510,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AverageCustomerReview is set.
      *
-     * @return true if AverageCustomerReview is set.
+     * @return bool True if AverageCustomerReview is set.
      */
     public function isSetAverageCustomerReview()
     {
@@ -556,7 +556,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NumberOfCustomerReviews is set.
      *
-     * @return true if NumberOfCustomerReviews is set.
+     * @return bool True if NumberOfCustomerReviews is set.
      */
     public function isSetNumberOfCustomerReviews()
     {
@@ -602,7 +602,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemDimensions is set.
      *
-     * @return true if ItemDimensions is set.
+     * @return bool True if ItemDimensions is set.
      */
     public function isSetItemDimensions()
     {
@@ -648,7 +648,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationId is set.
      *
-     * @return true if RecommendationId is set.
+     * @return bool True if RecommendationId is set.
      */
     public function isSetRecommendationId()
     {
@@ -694,7 +694,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationReason is set.
      *
-     * @return true if RecommendationReason is set.
+     * @return bool True if RecommendationReason is set.
      */
     public function isSetRecommendationReason()
     {

--- a/src/MWSRecommendationsSectionService/Model/GetLastUpdatedTimeForRecommendationsRequest.php
+++ b/src/MWSRecommendationsSectionService/Model/GetLastUpdatedTimeForRecommendationsRequest.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {

--- a/src/MWSRecommendationsSectionService/Model/GetLastUpdatedTimeForRecommendationsResponse.php
+++ b/src/MWSRecommendationsSectionService/Model/GetLastUpdatedTimeForRecommendationsResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GetLastUpdatedTimeForRecommendationsResult is set.
      *
-     * @return true if GetLastUpdatedTimeForRecommendationsResult is set.
+     * @return bool True if GetLastUpdatedTimeForRecommendationsResult is set.
      */
     public function isSetGetLastUpdatedTimeForRecommendationsResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSRecommendationsSectionService/Model/GetLastUpdatedTimeForRecommendationsResult.php
+++ b/src/MWSRecommendationsSectionService/Model/GetLastUpdatedTimeForRecommendationsResult.php
@@ -80,7 +80,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if InventoryRecommendationsLastUpdated is set.
      *
-     * @return true if InventoryRecommendationsLastUpdated is set.
+     * @return bool True if InventoryRecommendationsLastUpdated is set.
      */
     public function isSetInventoryRecommendationsLastUpdated()
     {
@@ -126,7 +126,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SelectionRecommendationsLastUpdated is set.
      *
-     * @return true if SelectionRecommendationsLastUpdated is set.
+     * @return bool True if SelectionRecommendationsLastUpdated is set.
      */
     public function isSetSelectionRecommendationsLastUpdated()
     {
@@ -172,7 +172,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FulfillmentRecommendationsLastUpdated is set.
      *
-     * @return true if FulfillmentRecommendationsLastUpdated is set.
+     * @return bool True if FulfillmentRecommendationsLastUpdated is set.
      */
     public function isSetFulfillmentRecommendationsLastUpdated()
     {
@@ -218,7 +218,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PricingRecommendationsLastUpdated is set.
      *
-     * @return true if PricingRecommendationsLastUpdated is set.
+     * @return bool True if PricingRecommendationsLastUpdated is set.
      */
     public function isSetPricingRecommendationsLastUpdated()
     {
@@ -264,7 +264,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GlobalSellingRecommendationsLastUpdated is set.
      *
-     * @return true if GlobalSellingRecommendationsLastUpdated is set.
+     * @return bool True if GlobalSellingRecommendationsLastUpdated is set.
      */
     public function isSetGlobalSellingRecommendationsLastUpdated()
     {
@@ -310,7 +310,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AdvertisingRecommendationsLastUpdated is set.
      *
-     * @return true if AdvertisingRecommendationsLastUpdated is set.
+     * @return bool True if AdvertisingRecommendationsLastUpdated is set.
      */
     public function isSetAdvertisingRecommendationsLastUpdated()
     {

--- a/src/MWSRecommendationsSectionService/Model/GetServiceStatusRequest.php
+++ b/src/MWSRecommendationsSectionService/Model/GetServiceStatusRequest.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {

--- a/src/MWSRecommendationsSectionService/Model/GetServiceStatusResponse.php
+++ b/src/MWSRecommendationsSectionService/Model/GetServiceStatusResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GetServiceStatusResult is set.
      *
-     * @return true if GetServiceStatusResult is set.
+     * @return bool True if GetServiceStatusResult is set.
      */
     public function isSetGetServiceStatusResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSRecommendationsSectionService/Model/GetServiceStatusResult.php
+++ b/src/MWSRecommendationsSectionService/Model/GetServiceStatusResult.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Status is set.
      *
-     * @return true if Status is set.
+     * @return bool True if Status is set.
      */
     public function isSetStatus()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Timestamp is set.
      *
-     * @return true if Timestamp is set.
+     * @return bool True if Timestamp is set.
      */
     public function isSetTimestamp()
     {

--- a/src/MWSRecommendationsSectionService/Model/GlobalSellingRecommendation.php
+++ b/src/MWSRecommendationsSectionService/Model/GlobalSellingRecommendation.php
@@ -96,7 +96,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LastUpdated is set.
      *
-     * @return true if LastUpdated is set.
+     * @return bool True if LastUpdated is set.
      */
     public function isSetLastUpdated()
     {
@@ -142,7 +142,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemIdentifier is set.
      *
-     * @return true if ItemIdentifier is set.
+     * @return bool True if ItemIdentifier is set.
      */
     public function isSetItemIdentifier()
     {
@@ -188,7 +188,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemName is set.
      *
-     * @return true if ItemName is set.
+     * @return bool True if ItemName is set.
      */
     public function isSetItemName()
     {
@@ -234,7 +234,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if BrandName is set.
      *
-     * @return true if BrandName is set.
+     * @return bool True if BrandName is set.
      */
     public function isSetBrandName()
     {
@@ -280,7 +280,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ProductCategory is set.
      *
-     * @return true if ProductCategory is set.
+     * @return bool True if ProductCategory is set.
      */
     public function isSetProductCategory()
     {
@@ -326,7 +326,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SalesRank is set.
      *
-     * @return true if SalesRank is set.
+     * @return bool True if SalesRank is set.
      */
     public function isSetSalesRank()
     {
@@ -372,7 +372,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if BuyboxPrice is set.
      *
-     * @return true if BuyboxPrice is set.
+     * @return bool True if BuyboxPrice is set.
      */
     public function isSetBuyboxPrice()
     {
@@ -418,7 +418,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NumberOfOffers is set.
      *
-     * @return true if NumberOfOffers is set.
+     * @return bool True if NumberOfOffers is set.
      */
     public function isSetNumberOfOffers()
     {
@@ -464,7 +464,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NumberOfOffersFulfilledByAmazon is set.
      *
-     * @return true if NumberOfOffersFulfilledByAmazon is set.
+     * @return bool True if NumberOfOffersFulfilledByAmazon is set.
      */
     public function isSetNumberOfOffersFulfilledByAmazon()
     {
@@ -510,7 +510,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AverageCustomerReview is set.
      *
-     * @return true if AverageCustomerReview is set.
+     * @return bool True if AverageCustomerReview is set.
      */
     public function isSetAverageCustomerReview()
     {
@@ -556,7 +556,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NumberOfCustomerReviews is set.
      *
-     * @return true if NumberOfCustomerReviews is set.
+     * @return bool True if NumberOfCustomerReviews is set.
      */
     public function isSetNumberOfCustomerReviews()
     {
@@ -602,7 +602,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemDimensions is set.
      *
-     * @return true if ItemDimensions is set.
+     * @return bool True if ItemDimensions is set.
      */
     public function isSetItemDimensions()
     {
@@ -648,7 +648,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationId is set.
      *
-     * @return true if RecommendationId is set.
+     * @return bool True if RecommendationId is set.
      */
     public function isSetRecommendationId()
     {
@@ -694,7 +694,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationReason is set.
      *
-     * @return true if RecommendationReason is set.
+     * @return bool True if RecommendationReason is set.
      */
     public function isSetRecommendationReason()
     {

--- a/src/MWSRecommendationsSectionService/Model/InventoryRecommendation.php
+++ b/src/MWSRecommendationsSectionService/Model/InventoryRecommendation.php
@@ -96,7 +96,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LastUpdated is set.
      *
-     * @return true if LastUpdated is set.
+     * @return bool True if LastUpdated is set.
      */
     public function isSetLastUpdated()
     {
@@ -142,7 +142,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemIdentifier is set.
      *
-     * @return true if ItemIdentifier is set.
+     * @return bool True if ItemIdentifier is set.
      */
     public function isSetItemIdentifier()
     {
@@ -188,7 +188,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemName is set.
      *
-     * @return true if ItemName is set.
+     * @return bool True if ItemName is set.
      */
     public function isSetItemName()
     {
@@ -234,7 +234,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FulfillmentChannel is set.
      *
-     * @return true if FulfillmentChannel is set.
+     * @return bool True if FulfillmentChannel is set.
      */
     public function isSetFulfillmentChannel()
     {
@@ -280,7 +280,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SalesForTheLast14Days is set.
      *
-     * @return true if SalesForTheLast14Days is set.
+     * @return bool True if SalesForTheLast14Days is set.
      */
     public function isSetSalesForTheLast14Days()
     {
@@ -326,7 +326,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SalesForTheLast30Days is set.
      *
-     * @return true if SalesForTheLast30Days is set.
+     * @return bool True if SalesForTheLast30Days is set.
      */
     public function isSetSalesForTheLast30Days()
     {
@@ -372,7 +372,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AvailableQuantity is set.
      *
-     * @return true if AvailableQuantity is set.
+     * @return bool True if AvailableQuantity is set.
      */
     public function isSetAvailableQuantity()
     {
@@ -418,7 +418,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DaysUntilStockRunsOut is set.
      *
-     * @return true if DaysUntilStockRunsOut is set.
+     * @return bool True if DaysUntilStockRunsOut is set.
      */
     public function isSetDaysUntilStockRunsOut()
     {
@@ -464,7 +464,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if InboundQuantity is set.
      *
-     * @return true if InboundQuantity is set.
+     * @return bool True if InboundQuantity is set.
      */
     public function isSetInboundQuantity()
     {
@@ -510,7 +510,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendedInboundQuantity is set.
      *
-     * @return true if RecommendedInboundQuantity is set.
+     * @return bool True if RecommendedInboundQuantity is set.
      */
     public function isSetRecommendedInboundQuantity()
     {
@@ -556,7 +556,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DaysOutOfStockLast30Days is set.
      *
-     * @return true if DaysOutOfStockLast30Days is set.
+     * @return bool True if DaysOutOfStockLast30Days is set.
      */
     public function isSetDaysOutOfStockLast30Days()
     {
@@ -602,7 +602,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LostSalesInLast30Days is set.
      *
-     * @return true if LostSalesInLast30Days is set.
+     * @return bool True if LostSalesInLast30Days is set.
      */
     public function isSetLostSalesInLast30Days()
     {
@@ -648,7 +648,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationId is set.
      *
-     * @return true if RecommendationId is set.
+     * @return bool True if RecommendationId is set.
      */
     public function isSetRecommendationId()
     {
@@ -694,7 +694,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationReason is set.
      *
-     * @return true if RecommendationReason is set.
+     * @return bool True if RecommendationReason is set.
      */
     public function isSetRecommendationReason()
     {

--- a/src/MWSRecommendationsSectionService/Model/ItemDimensions.php
+++ b/src/MWSRecommendationsSectionService/Model/ItemDimensions.php
@@ -76,7 +76,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Height is set.
      *
-     * @return true if Height is set.
+     * @return bool True if Height is set.
      */
     public function isSetHeight()
     {
@@ -122,7 +122,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Width is set.
      *
-     * @return true if Width is set.
+     * @return bool True if Width is set.
      */
     public function isSetWidth()
     {
@@ -168,7 +168,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Length is set.
      *
-     * @return true if Length is set.
+     * @return bool True if Length is set.
      */
     public function isSetLength()
     {
@@ -214,7 +214,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Weight is set.
      *
-     * @return true if Weight is set.
+     * @return bool True if Weight is set.
      */
     public function isSetWeight()
     {

--- a/src/MWSRecommendationsSectionService/Model/ListRecommendationsByNextTokenRequest.php
+++ b/src/MWSRecommendationsSectionService/Model/ListRecommendationsByNextTokenRequest.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/MWSRecommendationsSectionService/Model/ListRecommendationsByNextTokenResponse.php
+++ b/src/MWSRecommendationsSectionService/Model/ListRecommendationsByNextTokenResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ListRecommendationsByNextTokenResult is set.
      *
-     * @return true if ListRecommendationsByNextTokenResult is set.
+     * @return bool True if ListRecommendationsByNextTokenResult is set.
      */
     public function isSetListRecommendationsByNextTokenResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSRecommendationsSectionService/Model/ListRecommendationsByNextTokenResult.php
+++ b/src/MWSRecommendationsSectionService/Model/ListRecommendationsByNextTokenResult.php
@@ -99,7 +99,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if InventoryRecommendations is set.
      *
-     * @return true if InventoryRecommendations is set.
+     * @return bool True if InventoryRecommendations is set.
      */
     public function isSetInventoryRecommendations()
     {
@@ -163,7 +163,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SelectionRecommendations is set.
      *
-     * @return true if SelectionRecommendations is set.
+     * @return bool True if SelectionRecommendations is set.
      */
     public function isSetSelectionRecommendations()
     {
@@ -227,7 +227,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PricingRecommendations is set.
      *
-     * @return true if PricingRecommendations is set.
+     * @return bool True if PricingRecommendations is set.
      */
     public function isSetPricingRecommendations()
     {
@@ -291,7 +291,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FulfillmentRecommendations is set.
      *
-     * @return true if FulfillmentRecommendations is set.
+     * @return bool True if FulfillmentRecommendations is set.
      */
     public function isSetFulfillmentRecommendations()
     {
@@ -355,7 +355,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ListingQualityRecommendations is set.
      *
-     * @return true if ListingQualityRecommendations is set.
+     * @return bool True if ListingQualityRecommendations is set.
      */
     public function isSetListingQualityRecommendations()
     {
@@ -419,7 +419,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GlobalSellingRecommendations is set.
      *
-     * @return true if GlobalSellingRecommendations is set.
+     * @return bool True if GlobalSellingRecommendations is set.
      */
     public function isSetGlobalSellingRecommendations()
     {
@@ -483,7 +483,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AdvertisingRecommendations is set.
      *
-     * @return true if AdvertisingRecommendations is set.
+     * @return bool True if AdvertisingRecommendations is set.
      */
     public function isSetAdvertisingRecommendations()
     {
@@ -532,7 +532,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/MWSRecommendationsSectionService/Model/ListRecommendationsRequest.php
+++ b/src/MWSRecommendationsSectionService/Model/ListRecommendationsRequest.php
@@ -78,7 +78,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -124,7 +124,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -170,7 +170,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -216,7 +216,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationCategory is set.
      *
-     * @return true if RecommendationCategory is set.
+     * @return bool True if RecommendationCategory is set.
      */
     public function isSetRecommendationCategory()
     {
@@ -277,7 +277,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CategoryQueryList is set.
      *
-     * @return true if CategoryQueryList is set.
+     * @return bool True if CategoryQueryList is set.
      */
     public function isSetCategoryQueryList()
     {

--- a/src/MWSRecommendationsSectionService/Model/ListRecommendationsResponse.php
+++ b/src/MWSRecommendationsSectionService/Model/ListRecommendationsResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ListRecommendationsResult is set.
      *
-     * @return true if ListRecommendationsResult is set.
+     * @return bool True if ListRecommendationsResult is set.
      */
     public function isSetListRecommendationsResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSRecommendationsSectionService/Model/ListRecommendationsResult.php
+++ b/src/MWSRecommendationsSectionService/Model/ListRecommendationsResult.php
@@ -99,7 +99,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if InventoryRecommendations is set.
      *
-     * @return true if InventoryRecommendations is set.
+     * @return bool True if InventoryRecommendations is set.
      */
     public function isSetInventoryRecommendations()
     {
@@ -163,7 +163,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SelectionRecommendations is set.
      *
-     * @return true if SelectionRecommendations is set.
+     * @return bool True if SelectionRecommendations is set.
      */
     public function isSetSelectionRecommendations()
     {
@@ -227,7 +227,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PricingRecommendations is set.
      *
-     * @return true if PricingRecommendations is set.
+     * @return bool True if PricingRecommendations is set.
      */
     public function isSetPricingRecommendations()
     {
@@ -291,7 +291,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FulfillmentRecommendations is set.
      *
-     * @return true if FulfillmentRecommendations is set.
+     * @return bool True if FulfillmentRecommendations is set.
      */
     public function isSetFulfillmentRecommendations()
     {
@@ -355,7 +355,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ListingQualityRecommendations is set.
      *
-     * @return true if ListingQualityRecommendations is set.
+     * @return bool True if ListingQualityRecommendations is set.
      */
     public function isSetListingQualityRecommendations()
     {
@@ -419,7 +419,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GlobalSellingRecommendations is set.
      *
-     * @return true if GlobalSellingRecommendations is set.
+     * @return bool True if GlobalSellingRecommendations is set.
      */
     public function isSetGlobalSellingRecommendations()
     {
@@ -483,7 +483,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AdvertisingRecommendations is set.
      *
-     * @return true if AdvertisingRecommendations is set.
+     * @return bool True if AdvertisingRecommendations is set.
      */
     public function isSetAdvertisingRecommendations()
     {
@@ -532,7 +532,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/MWSRecommendationsSectionService/Model/ListingQualityRecommendation.php
+++ b/src/MWSRecommendationsSectionService/Model/ListingQualityRecommendation.php
@@ -82,7 +82,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if QualitySet is set.
      *
-     * @return true if QualitySet is set.
+     * @return bool True if QualitySet is set.
      */
     public function isSetQualitySet()
     {
@@ -128,7 +128,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DefectGroup is set.
      *
-     * @return true if DefectGroup is set.
+     * @return bool True if DefectGroup is set.
      */
     public function isSetDefectGroup()
     {
@@ -174,7 +174,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DefectAttribute is set.
      *
-     * @return true if DefectAttribute is set.
+     * @return bool True if DefectAttribute is set.
      */
     public function isSetDefectAttribute()
     {
@@ -220,7 +220,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemIdentifier is set.
      *
-     * @return true if ItemIdentifier is set.
+     * @return bool True if ItemIdentifier is set.
      */
     public function isSetItemIdentifier()
     {
@@ -266,7 +266,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemName is set.
      *
-     * @return true if ItemName is set.
+     * @return bool True if ItemName is set.
      */
     public function isSetItemName()
     {
@@ -312,7 +312,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationId is set.
      *
-     * @return true if RecommendationId is set.
+     * @return bool True if RecommendationId is set.
      */
     public function isSetRecommendationId()
     {
@@ -358,7 +358,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationReason is set.
      *
-     * @return true if RecommendationReason is set.
+     * @return bool True if RecommendationReason is set.
      */
     public function isSetRecommendationReason()
     {

--- a/src/MWSRecommendationsSectionService/Model/Price.php
+++ b/src/MWSRecommendationsSectionService/Model/Price.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CurrencyCode is set.
      *
-     * @return true if CurrencyCode is set.
+     * @return bool True if CurrencyCode is set.
      */
     public function isSetCurrencyCode()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Amount is set.
      *
-     * @return true if Amount is set.
+     * @return bool True if Amount is set.
      */
     public function isSetAmount()
     {

--- a/src/MWSRecommendationsSectionService/Model/PricingRecommendation.php
+++ b/src/MWSRecommendationsSectionService/Model/PricingRecommendation.php
@@ -102,7 +102,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LastUpdated is set.
      *
-     * @return true if LastUpdated is set.
+     * @return bool True if LastUpdated is set.
      */
     public function isSetLastUpdated()
     {
@@ -148,7 +148,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemIdentifier is set.
      *
-     * @return true if ItemIdentifier is set.
+     * @return bool True if ItemIdentifier is set.
      */
     public function isSetItemIdentifier()
     {
@@ -194,7 +194,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemName is set.
      *
-     * @return true if ItemName is set.
+     * @return bool True if ItemName is set.
      */
     public function isSetItemName()
     {
@@ -240,7 +240,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Condition is set.
      *
-     * @return true if Condition is set.
+     * @return bool True if Condition is set.
      */
     public function isSetCondition()
     {
@@ -286,7 +286,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SubCondition is set.
      *
-     * @return true if SubCondition is set.
+     * @return bool True if SubCondition is set.
      */
     public function isSetSubCondition()
     {
@@ -332,7 +332,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if FulfillmentChannel is set.
      *
-     * @return true if FulfillmentChannel is set.
+     * @return bool True if FulfillmentChannel is set.
      */
     public function isSetFulfillmentChannel()
     {
@@ -378,7 +378,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if YourPricePlusShipping is set.
      *
-     * @return true if YourPricePlusShipping is set.
+     * @return bool True if YourPricePlusShipping is set.
      */
     public function isSetYourPricePlusShipping()
     {
@@ -424,7 +424,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LowestPricePlusShipping is set.
      *
-     * @return true if LowestPricePlusShipping is set.
+     * @return bool True if LowestPricePlusShipping is set.
      */
     public function isSetLowestPricePlusShipping()
     {
@@ -470,7 +470,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if PriceDifferenceToLowPrice is set.
      *
-     * @return true if PriceDifferenceToLowPrice is set.
+     * @return bool True if PriceDifferenceToLowPrice is set.
      */
     public function isSetPriceDifferenceToLowPrice()
     {
@@ -516,7 +516,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MedianPricePlusShipping is set.
      *
-     * @return true if MedianPricePlusShipping is set.
+     * @return bool True if MedianPricePlusShipping is set.
      */
     public function isSetMedianPricePlusShipping()
     {
@@ -562,7 +562,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LowestMerchantFulfilledOfferPrice is set.
      *
-     * @return true if LowestMerchantFulfilledOfferPrice is set.
+     * @return bool True if LowestMerchantFulfilledOfferPrice is set.
      */
     public function isSetLowestMerchantFulfilledOfferPrice()
     {
@@ -608,7 +608,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LowestAmazonFulfilledOfferPrice is set.
      *
-     * @return true if LowestAmazonFulfilledOfferPrice is set.
+     * @return bool True if LowestAmazonFulfilledOfferPrice is set.
      */
     public function isSetLowestAmazonFulfilledOfferPrice()
     {
@@ -654,7 +654,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NumberOfOffers is set.
      *
-     * @return true if NumberOfOffers is set.
+     * @return bool True if NumberOfOffers is set.
      */
     public function isSetNumberOfOffers()
     {
@@ -700,7 +700,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NumberOfMerchantFulfilledOffers is set.
      *
-     * @return true if NumberOfMerchantFulfilledOffers is set.
+     * @return bool True if NumberOfMerchantFulfilledOffers is set.
      */
     public function isSetNumberOfMerchantFulfilledOffers()
     {
@@ -746,7 +746,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NumberOfAmazonFulfilledOffers is set.
      *
-     * @return true if NumberOfAmazonFulfilledOffers is set.
+     * @return bool True if NumberOfAmazonFulfilledOffers is set.
      */
     public function isSetNumberOfAmazonFulfilledOffers()
     {
@@ -792,7 +792,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationId is set.
      *
-     * @return true if RecommendationId is set.
+     * @return bool True if RecommendationId is set.
      */
     public function isSetRecommendationId()
     {
@@ -838,7 +838,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationReason is set.
      *
-     * @return true if RecommendationReason is set.
+     * @return bool True if RecommendationReason is set.
      */
     public function isSetRecommendationReason()
     {

--- a/src/MWSRecommendationsSectionService/Model/ProductIdentifier.php
+++ b/src/MWSRecommendationsSectionService/Model/ProductIdentifier.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Asin is set.
      *
-     * @return true if Asin is set.
+     * @return bool True if Asin is set.
      */
     public function isSetAsin()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Sku is set.
      *
-     * @return true if Sku is set.
+     * @return bool True if Sku is set.
      */
     public function isSetSku()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Upc is set.
      *
-     * @return true if Upc is set.
+     * @return bool True if Upc is set.
      */
     public function isSetUpc()
     {

--- a/src/MWSRecommendationsSectionService/Model/ResponseMetadata.php
+++ b/src/MWSRecommendationsSectionService/Model/ResponseMetadata.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RequestId is set.
      *
-     * @return true if RequestId is set.
+     * @return bool True if RequestId is set.
      */
     public function isSetRequestId()
     {

--- a/src/MWSRecommendationsSectionService/Model/SelectionRecommendation.php
+++ b/src/MWSRecommendationsSectionService/Model/SelectionRecommendation.php
@@ -92,7 +92,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if LastUpdated is set.
      *
-     * @return true if LastUpdated is set.
+     * @return bool True if LastUpdated is set.
      */
     public function isSetLastUpdated()
     {
@@ -138,7 +138,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemIdentifier is set.
      *
-     * @return true if ItemIdentifier is set.
+     * @return bool True if ItemIdentifier is set.
      */
     public function isSetItemIdentifier()
     {
@@ -184,7 +184,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ItemName is set.
      *
-     * @return true if ItemName is set.
+     * @return bool True if ItemName is set.
      */
     public function isSetItemName()
     {
@@ -230,7 +230,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if BrandName is set.
      *
-     * @return true if BrandName is set.
+     * @return bool True if BrandName is set.
      */
     public function isSetBrandName()
     {
@@ -276,7 +276,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ProductCategory is set.
      *
-     * @return true if ProductCategory is set.
+     * @return bool True if ProductCategory is set.
      */
     public function isSetProductCategory()
     {
@@ -322,7 +322,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SalesRank is set.
      *
-     * @return true if SalesRank is set.
+     * @return bool True if SalesRank is set.
      */
     public function isSetSalesRank()
     {
@@ -368,7 +368,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if BuyboxPrice is set.
      *
-     * @return true if BuyboxPrice is set.
+     * @return bool True if BuyboxPrice is set.
      */
     public function isSetBuyboxPrice()
     {
@@ -414,7 +414,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NumberOfOffers is set.
      *
-     * @return true if NumberOfOffers is set.
+     * @return bool True if NumberOfOffers is set.
      */
     public function isSetNumberOfOffers()
     {
@@ -460,7 +460,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AverageCustomerReview is set.
      *
-     * @return true if AverageCustomerReview is set.
+     * @return bool True if AverageCustomerReview is set.
      */
     public function isSetAverageCustomerReview()
     {
@@ -506,7 +506,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NumberOfCustomerReviews is set.
      *
-     * @return true if NumberOfCustomerReviews is set.
+     * @return bool True if NumberOfCustomerReviews is set.
      */
     public function isSetNumberOfCustomerReviews()
     {
@@ -552,7 +552,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationId is set.
      *
-     * @return true if RecommendationId is set.
+     * @return bool True if RecommendationId is set.
      */
     public function isSetRecommendationId()
     {
@@ -598,7 +598,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RecommendationReason is set.
      *
-     * @return true if RecommendationReason is set.
+     * @return bool True if RecommendationReason is set.
      */
     public function isSetRecommendationReason()
     {

--- a/src/MWSRecommendationsSectionService/Model/WeightMeasure.php
+++ b/src/MWSRecommendationsSectionService/Model/WeightMeasure.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Value is set.
      *
-     * @return true if Value is set.
+     * @return bool True if Value is set.
      */
     public function isSetValue()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Unit is set.
      *
-     * @return true if Unit is set.
+     * @return bool True if Unit is set.
      */
     public function isSetUnit()
     {

--- a/src/MWSSubscriptionsService/Model.php
+++ b/src/MWSSubscriptionsService/Model.php
@@ -400,7 +400,7 @@ abstract class MWSSubscriptionsService_Model
     * Checks  whether passed variable is an associative array
     *
     * @param mixed $var
-    * @return TRUE if passed variable is an associative array
+    * @return bool True if passed variable is an associative array
     */
     private function _isAssociativeArray($var)
     {
@@ -411,7 +411,7 @@ abstract class MWSSubscriptionsService_Model
     * Checks  whether passed variable is DOMElement
     *
     * @param mixed $var
-    * @return TRUE if passed variable is DOMElement
+    * @return bool True if passed variable is DOMElement
     */
     private function _isDOMElement($var)
     {
@@ -422,7 +422,7 @@ abstract class MWSSubscriptionsService_Model
     * Checks  whether passed variable is numeric array
     *
     * @param mixed $var
-    * @return TRUE if passed variable is an numeric array
+    * @return bool True if passed variable is an numeric array
     */
     protected function _isNumericArray($var)
     {

--- a/src/MWSSubscriptionsService/Model/AttributeKeyValue.php
+++ b/src/MWSSubscriptionsService/Model/AttributeKeyValue.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Key is set.
      *
-     * @return true if Key is set.
+     * @return bool True if Key is set.
      */
     public function isSetKey()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Value is set.
      *
-     * @return true if Value is set.
+     * @return bool True if Value is set.
      */
     public function isSetValue()
     {

--- a/src/MWSSubscriptionsService/Model/AttributeKeyValueList.php
+++ b/src/MWSSubscriptionsService/Model/AttributeKeyValueList.php
@@ -85,7 +85,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/MWSSubscriptionsService/Model/CreateSubscriptionInput.php
+++ b/src/MWSSubscriptionsService/Model/CreateSubscriptionInput.php
@@ -76,7 +76,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -122,7 +122,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -168,7 +168,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -214,7 +214,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Subscription is set.
      *
-     * @return true if Subscription is set.
+     * @return bool True if Subscription is set.
      */
     public function isSetSubscription()
     {

--- a/src/MWSSubscriptionsService/Model/CreateSubscriptionResponse.php
+++ b/src/MWSSubscriptionsService/Model/CreateSubscriptionResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if CreateSubscriptionResult is set.
      *
-     * @return true if CreateSubscriptionResult is set.
+     * @return bool True if CreateSubscriptionResult is set.
      */
     public function isSetCreateSubscriptionResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSSubscriptionsService/Model/DeleteSubscriptionInput.php
+++ b/src/MWSSubscriptionsService/Model/DeleteSubscriptionInput.php
@@ -78,7 +78,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -124,7 +124,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -170,7 +170,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -216,7 +216,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NotificationType is set.
      *
-     * @return true if NotificationType is set.
+     * @return bool True if NotificationType is set.
      */
     public function isSetNotificationType()
     {
@@ -262,7 +262,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Destination is set.
      *
-     * @return true if Destination is set.
+     * @return bool True if Destination is set.
      */
     public function isSetDestination()
     {

--- a/src/MWSSubscriptionsService/Model/DeleteSubscriptionResponse.php
+++ b/src/MWSSubscriptionsService/Model/DeleteSubscriptionResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DeleteSubscriptionResult is set.
      *
-     * @return true if DeleteSubscriptionResult is set.
+     * @return bool True if DeleteSubscriptionResult is set.
      */
     public function isSetDeleteSubscriptionResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSSubscriptionsService/Model/DeregisterDestinationInput.php
+++ b/src/MWSSubscriptionsService/Model/DeregisterDestinationInput.php
@@ -76,7 +76,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -122,7 +122,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -168,7 +168,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -214,7 +214,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Destination is set.
      *
-     * @return true if Destination is set.
+     * @return bool True if Destination is set.
      */
     public function isSetDestination()
     {

--- a/src/MWSSubscriptionsService/Model/DeregisterDestinationResponse.php
+++ b/src/MWSSubscriptionsService/Model/DeregisterDestinationResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DeregisterDestinationResult is set.
      *
-     * @return true if DeregisterDestinationResult is set.
+     * @return bool True if DeregisterDestinationResult is set.
      */
     public function isSetDeregisterDestinationResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSSubscriptionsService/Model/Destination.php
+++ b/src/MWSSubscriptionsService/Model/Destination.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DeliveryChannel is set.
      *
-     * @return true if DeliveryChannel is set.
+     * @return bool True if DeliveryChannel is set.
      */
     public function isSetDeliveryChannel()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if AttributeList is set.
      *
-     * @return true if AttributeList is set.
+     * @return bool True if AttributeList is set.
      */
     public function isSetAttributeList()
     {

--- a/src/MWSSubscriptionsService/Model/DestinationList.php
+++ b/src/MWSSubscriptionsService/Model/DestinationList.php
@@ -85,7 +85,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/MWSSubscriptionsService/Model/GetServiceStatusRequest.php
+++ b/src/MWSSubscriptionsService/Model/GetServiceStatusRequest.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {

--- a/src/MWSSubscriptionsService/Model/GetServiceStatusResponse.php
+++ b/src/MWSSubscriptionsService/Model/GetServiceStatusResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GetServiceStatusResult is set.
      *
-     * @return true if GetServiceStatusResult is set.
+     * @return bool True if GetServiceStatusResult is set.
      */
     public function isSetGetServiceStatusResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSSubscriptionsService/Model/GetServiceStatusResult.php
+++ b/src/MWSSubscriptionsService/Model/GetServiceStatusResult.php
@@ -72,7 +72,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Status is set.
      *
-     * @return true if Status is set.
+     * @return bool True if Status is set.
      */
     public function isSetStatus()
     {
@@ -118,7 +118,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Timestamp is set.
      *
-     * @return true if Timestamp is set.
+     * @return bool True if Timestamp is set.
      */
     public function isSetTimestamp()
     {

--- a/src/MWSSubscriptionsService/Model/GetSubscriptionInput.php
+++ b/src/MWSSubscriptionsService/Model/GetSubscriptionInput.php
@@ -78,7 +78,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -124,7 +124,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -170,7 +170,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -216,7 +216,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NotificationType is set.
      *
-     * @return true if NotificationType is set.
+     * @return bool True if NotificationType is set.
      */
     public function isSetNotificationType()
     {
@@ -262,7 +262,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Destination is set.
      *
-     * @return true if Destination is set.
+     * @return bool True if Destination is set.
      */
     public function isSetDestination()
     {

--- a/src/MWSSubscriptionsService/Model/GetSubscriptionResponse.php
+++ b/src/MWSSubscriptionsService/Model/GetSubscriptionResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if GetSubscriptionResult is set.
      *
-     * @return true if GetSubscriptionResult is set.
+     * @return bool True if GetSubscriptionResult is set.
      */
     public function isSetGetSubscriptionResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSSubscriptionsService/Model/GetSubscriptionResult.php
+++ b/src/MWSSubscriptionsService/Model/GetSubscriptionResult.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Subscription is set.
      *
-     * @return true if Subscription is set.
+     * @return bool True if Subscription is set.
      */
     public function isSetSubscription()
     {

--- a/src/MWSSubscriptionsService/Model/ListRegisteredDestinationsInput.php
+++ b/src/MWSSubscriptionsService/Model/ListRegisteredDestinationsInput.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {

--- a/src/MWSSubscriptionsService/Model/ListRegisteredDestinationsResponse.php
+++ b/src/MWSSubscriptionsService/Model/ListRegisteredDestinationsResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ListRegisteredDestinationsResult is set.
      *
-     * @return true if ListRegisteredDestinationsResult is set.
+     * @return bool True if ListRegisteredDestinationsResult is set.
      */
     public function isSetListRegisteredDestinationsResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSSubscriptionsService/Model/ListRegisteredDestinationsResult.php
+++ b/src/MWSSubscriptionsService/Model/ListRegisteredDestinationsResult.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if DestinationList is set.
      *
-     * @return true if DestinationList is set.
+     * @return bool True if DestinationList is set.
      */
     public function isSetDestinationList()
     {

--- a/src/MWSSubscriptionsService/Model/ListSubscriptionsInput.php
+++ b/src/MWSSubscriptionsService/Model/ListSubscriptionsInput.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {

--- a/src/MWSSubscriptionsService/Model/ListSubscriptionsResponse.php
+++ b/src/MWSSubscriptionsService/Model/ListSubscriptionsResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ListSubscriptionsResult is set.
      *
-     * @return true if ListSubscriptionsResult is set.
+     * @return bool True if ListSubscriptionsResult is set.
      */
     public function isSetListSubscriptionsResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSSubscriptionsService/Model/ListSubscriptionsResult.php
+++ b/src/MWSSubscriptionsService/Model/ListSubscriptionsResult.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SubscriptionList is set.
      *
-     * @return true if SubscriptionList is set.
+     * @return bool True if SubscriptionList is set.
      */
     public function isSetSubscriptionList()
     {

--- a/src/MWSSubscriptionsService/Model/RegisterDestinationInput.php
+++ b/src/MWSSubscriptionsService/Model/RegisterDestinationInput.php
@@ -76,7 +76,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -122,7 +122,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -168,7 +168,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -214,7 +214,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Destination is set.
      *
-     * @return true if Destination is set.
+     * @return bool True if Destination is set.
      */
     public function isSetDestination()
     {

--- a/src/MWSSubscriptionsService/Model/RegisterDestinationResponse.php
+++ b/src/MWSSubscriptionsService/Model/RegisterDestinationResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RegisterDestinationResult is set.
      *
-     * @return true if RegisterDestinationResult is set.
+     * @return bool True if RegisterDestinationResult is set.
      */
     public function isSetRegisterDestinationResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSSubscriptionsService/Model/ResponseMetadata.php
+++ b/src/MWSSubscriptionsService/Model/ResponseMetadata.php
@@ -70,7 +70,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if RequestId is set.
      *
-     * @return true if RequestId is set.
+     * @return bool True if RequestId is set.
      */
     public function isSetRequestId()
     {

--- a/src/MWSSubscriptionsService/Model/SendTestNotificationToDestinationInput.php
+++ b/src/MWSSubscriptionsService/Model/SendTestNotificationToDestinationInput.php
@@ -76,7 +76,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -122,7 +122,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -168,7 +168,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -214,7 +214,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Destination is set.
      *
-     * @return true if Destination is set.
+     * @return bool True if Destination is set.
      */
     public function isSetDestination()
     {

--- a/src/MWSSubscriptionsService/Model/SendTestNotificationToDestinationResponse.php
+++ b/src/MWSSubscriptionsService/Model/SendTestNotificationToDestinationResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SendTestNotificationToDestinationResult is set.
      *
-     * @return true if SendTestNotificationToDestinationResult is set.
+     * @return bool True if SendTestNotificationToDestinationResult is set.
      */
     public function isSetSendTestNotificationToDestinationResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MWSSubscriptionsService/Model/Subscription.php
+++ b/src/MWSSubscriptionsService/Model/Subscription.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if NotificationType is set.
      *
-     * @return true if NotificationType is set.
+     * @return bool True if NotificationType is set.
      */
     public function isSetNotificationType()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Destination is set.
      *
-     * @return true if Destination is set.
+     * @return bool True if Destination is set.
      */
     public function isSetDestination()
     {
@@ -144,7 +144,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check the value of IsEnabled.
      *
-     * @return true if IsEnabled is set to true.
+     * @return bool True if IsEnabled is set to true.
      */
     public function isIsEnabled()
     {
@@ -176,7 +176,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if IsEnabled is set.
      *
-     * @return true if IsEnabled is set.
+     * @return bool True if IsEnabled is set.
      */
     public function isSetIsEnabled()
     {

--- a/src/MWSSubscriptionsService/Model/SubscriptionList.php
+++ b/src/MWSSubscriptionsService/Model/SubscriptionList.php
@@ -85,7 +85,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if member is set.
      *
-     * @return true if member is set.
+     * @return bool True if member is set.
      */
     public function isSetmember()
     {

--- a/src/MWSSubscriptionsService/Model/UpdateSubscriptionInput.php
+++ b/src/MWSSubscriptionsService/Model/UpdateSubscriptionInput.php
@@ -76,7 +76,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -122,7 +122,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -168,7 +168,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -214,7 +214,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if Subscription is set.
      *
-     * @return true if Subscription is set.
+     * @return bool True if Subscription is set.
      */
     public function isSetSubscription()
     {

--- a/src/MWSSubscriptionsService/Model/UpdateSubscriptionResponse.php
+++ b/src/MWSSubscriptionsService/Model/UpdateSubscriptionResponse.php
@@ -74,7 +74,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if UpdateSubscriptionResult is set.
      *
-     * @return true if UpdateSubscriptionResult is set.
+     * @return bool True if UpdateSubscriptionResult is set.
      */
     public function isSetUpdateSubscriptionResult()
     {
@@ -120,7 +120,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -166,7 +166,7 @@ require_once (dirname(__FILE__) . '/../Model.php');
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebService/Model.php
+++ b/src/MarketplaceWebService/Model.php
@@ -278,7 +278,7 @@ abstract class MarketplaceWebService_Model
      * Checks  whether passed variable is an associative array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an associative array
+     * @return bool True if passed variable is an associative array
      */
     private function isAssociativeArray($var)
     {
@@ -289,7 +289,7 @@ abstract class MarketplaceWebService_Model
      * Checks  whether passed variable is DOMElement
      *
      * @param mixed $var
-     * @return TRUE if passed variable is DOMElement
+     * @return bool True if passed variable is DOMElement
      */
     private function isDOMElement($var)
     {
@@ -300,7 +300,7 @@ abstract class MarketplaceWebService_Model
      * Checks  whether passed variable is numeric array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an numeric array
+     * @return bool True if passed variable is an numeric array
      */
     protected function isNumericArray($var)
     {

--- a/src/MarketplaceWebServiceOrders/Model.php
+++ b/src/MarketplaceWebServiceOrders/Model.php
@@ -404,7 +404,7 @@ abstract class MarketplaceWebServiceOrders_Model
      * Checks  whether passed variable is an associative array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an associative array
+     * @return bool True if passed variable is an associative array
      */
     private function _isAssociativeArray($var)
     {
@@ -415,7 +415,7 @@ abstract class MarketplaceWebServiceOrders_Model
      * Checks  whether passed variable is DOMElement
      *
      * @param mixed $var
-     * @return TRUE if passed variable is DOMElement
+     * @return bool True if passed variable is DOMElement
      */
     private function _isDOMElement($var)
     {
@@ -426,7 +426,7 @@ abstract class MarketplaceWebServiceOrders_Model
      * Checks  whether passed variable is numeric array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an numeric array
+     * @return bool True if passed variable is an numeric array
      */
     protected function _isNumericArray($var)
     {

--- a/src/MarketplaceWebServiceOrders/Model/Address.php
+++ b/src/MarketplaceWebServiceOrders/Model/Address.php
@@ -83,7 +83,7 @@ class MarketplaceWebServiceOrders_Model_Address extends MarketplaceWebServiceOrd
     /**
      * Check to see if Name is set.
      *
-     * @return true if Name is set.
+     * @return bool True if Name is set.
      */
     public function isSetName()
     {
@@ -129,7 +129,7 @@ class MarketplaceWebServiceOrders_Model_Address extends MarketplaceWebServiceOrd
     /**
      * Check to see if AddressLine1 is set.
      *
-     * @return true if AddressLine1 is set.
+     * @return bool True if AddressLine1 is set.
      */
     public function isSetAddressLine1()
     {
@@ -175,7 +175,7 @@ class MarketplaceWebServiceOrders_Model_Address extends MarketplaceWebServiceOrd
     /**
      * Check to see if AddressLine2 is set.
      *
-     * @return true if AddressLine2 is set.
+     * @return bool True if AddressLine2 is set.
      */
     public function isSetAddressLine2()
     {
@@ -221,7 +221,7 @@ class MarketplaceWebServiceOrders_Model_Address extends MarketplaceWebServiceOrd
     /**
      * Check to see if AddressLine3 is set.
      *
-     * @return true if AddressLine3 is set.
+     * @return bool True if AddressLine3 is set.
      */
     public function isSetAddressLine3()
     {
@@ -267,7 +267,7 @@ class MarketplaceWebServiceOrders_Model_Address extends MarketplaceWebServiceOrd
     /**
      * Check to see if City is set.
      *
-     * @return true if City is set.
+     * @return bool True if City is set.
      */
     public function isSetCity()
     {
@@ -313,7 +313,7 @@ class MarketplaceWebServiceOrders_Model_Address extends MarketplaceWebServiceOrd
     /**
      * Check to see if County is set.
      *
-     * @return true if County is set.
+     * @return bool True if County is set.
      */
     public function isSetCounty()
     {
@@ -359,7 +359,7 @@ class MarketplaceWebServiceOrders_Model_Address extends MarketplaceWebServiceOrd
     /**
      * Check to see if District is set.
      *
-     * @return true if District is set.
+     * @return bool True if District is set.
      */
     public function isSetDistrict()
     {
@@ -405,7 +405,7 @@ class MarketplaceWebServiceOrders_Model_Address extends MarketplaceWebServiceOrd
     /**
      * Check to see if StateOrRegion is set.
      *
-     * @return true if StateOrRegion is set.
+     * @return bool True if StateOrRegion is set.
      */
     public function isSetStateOrRegion()
     {
@@ -451,7 +451,7 @@ class MarketplaceWebServiceOrders_Model_Address extends MarketplaceWebServiceOrd
     /**
      * Check to see if PostalCode is set.
      *
-     * @return true if PostalCode is set.
+     * @return bool True if PostalCode is set.
      */
     public function isSetPostalCode()
     {
@@ -497,7 +497,7 @@ class MarketplaceWebServiceOrders_Model_Address extends MarketplaceWebServiceOrd
     /**
      * Check to see if CountryCode is set.
      *
-     * @return true if CountryCode is set.
+     * @return bool True if CountryCode is set.
      */
     public function isSetCountryCode()
     {
@@ -543,7 +543,7 @@ class MarketplaceWebServiceOrders_Model_Address extends MarketplaceWebServiceOrd
     /**
      * Check to see if Phone is set.
      *
-     * @return true if Phone is set.
+     * @return bool True if Phone is set.
      */
     public function isSetPhone()
     {

--- a/src/MarketplaceWebServiceOrders/Model/GetOrderRequest.php
+++ b/src/MarketplaceWebServiceOrders/Model/GetOrderRequest.php
@@ -67,7 +67,7 @@ class MarketplaceWebServiceOrders_Model_GetOrderRequest extends MarketplaceWebSe
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class MarketplaceWebServiceOrders_Model_GetOrderRequest extends MarketplaceWebSe
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -173,7 +173,7 @@ class MarketplaceWebServiceOrders_Model_GetOrderRequest extends MarketplaceWebSe
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {

--- a/src/MarketplaceWebServiceOrders/Model/GetOrderResponse.php
+++ b/src/MarketplaceWebServiceOrders/Model/GetOrderResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceOrders_Model_GetOrderResponse extends MarketplaceWebS
     /**
      * Check to see if GetOrderResult is set.
      *
-     * @return true if GetOrderResult is set.
+     * @return bool True if GetOrderResult is set.
      */
     public function isSetGetOrderResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceOrders_Model_GetOrderResponse extends MarketplaceWebS
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceOrders_Model_GetOrderResponse extends MarketplaceWebS
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceOrders/Model/GetOrderResult.php
+++ b/src/MarketplaceWebServiceOrders/Model/GetOrderResult.php
@@ -81,7 +81,7 @@ class MarketplaceWebServiceOrders_Model_GetOrderResult extends MarketplaceWebSer
     /**
      * Check to see if Orders is set.
      *
-     * @return true if Orders is set.
+     * @return bool True if Orders is set.
      */
     public function isSetOrders()
     {

--- a/src/MarketplaceWebServiceOrders/Model/GetServiceStatusRequest.php
+++ b/src/MarketplaceWebServiceOrders/Model/GetServiceStatusRequest.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceOrders_Model_GetServiceStatusRequest extends Marketpl
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceOrders_Model_GetServiceStatusRequest extends Marketpl
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {

--- a/src/MarketplaceWebServiceOrders/Model/GetServiceStatusResponse.php
+++ b/src/MarketplaceWebServiceOrders/Model/GetServiceStatusResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceOrders_Model_GetServiceStatusResponse extends Marketp
     /**
      * Check to see if GetServiceStatusResult is set.
      *
-     * @return true if GetServiceStatusResult is set.
+     * @return bool True if GetServiceStatusResult is set.
      */
     public function isSetGetServiceStatusResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceOrders_Model_GetServiceStatusResponse extends Marketp
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceOrders_Model_GetServiceStatusResponse extends Marketp
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceOrders/Model/GetServiceStatusResult.php
+++ b/src/MarketplaceWebServiceOrders/Model/GetServiceStatusResult.php
@@ -73,7 +73,7 @@ class MarketplaceWebServiceOrders_Model_GetServiceStatusResult extends Marketpla
     /**
      * Check to see if Status is set.
      *
-     * @return true if Status is set.
+     * @return bool True if Status is set.
      */
     public function isSetStatus()
     {
@@ -119,7 +119,7 @@ class MarketplaceWebServiceOrders_Model_GetServiceStatusResult extends Marketpla
     /**
      * Check to see if Timestamp is set.
      *
-     * @return true if Timestamp is set.
+     * @return bool True if Timestamp is set.
      */
     public function isSetTimestamp()
     {
@@ -165,7 +165,7 @@ class MarketplaceWebServiceOrders_Model_GetServiceStatusResult extends Marketpla
     /**
      * Check to see if MessageId is set.
      *
-     * @return true if MessageId is set.
+     * @return bool True if MessageId is set.
      */
     public function isSetMessageId()
     {
@@ -225,7 +225,7 @@ class MarketplaceWebServiceOrders_Model_GetServiceStatusResult extends Marketpla
     /**
      * Check to see if Messages is set.
      *
-     * @return true if Messages is set.
+     * @return bool True if Messages is set.
      */
     public function isSetMessages()
     {

--- a/src/MarketplaceWebServiceOrders/Model/InvoiceData.php
+++ b/src/MarketplaceWebServiceOrders/Model/InvoiceData.php
@@ -69,7 +69,7 @@ class MarketplaceWebServiceOrders_Model_InvoiceData extends MarketplaceWebServic
     /**
      * Check to see if InvoiceRequirement is set.
      *
-     * @return true if InvoiceRequirement is set.
+     * @return bool True if InvoiceRequirement is set.
      */
     public function isSetInvoiceRequirement()
     {
@@ -115,7 +115,7 @@ class MarketplaceWebServiceOrders_Model_InvoiceData extends MarketplaceWebServic
     /**
      * Check to see if BuyerSelectedInvoiceCategory is set.
      *
-     * @return true if BuyerSelectedInvoiceCategory is set.
+     * @return bool True if BuyerSelectedInvoiceCategory is set.
      */
     public function isSetBuyerSelectedInvoiceCategory()
     {
@@ -161,7 +161,7 @@ class MarketplaceWebServiceOrders_Model_InvoiceData extends MarketplaceWebServic
     /**
      * Check to see if InvoiceTitle is set.
      *
-     * @return true if InvoiceTitle is set.
+     * @return bool True if InvoiceTitle is set.
      */
     public function isSetInvoiceTitle()
     {
@@ -207,7 +207,7 @@ class MarketplaceWebServiceOrders_Model_InvoiceData extends MarketplaceWebServic
     /**
      * Check to see if InvoiceInformation is set.
      *
-     * @return true if InvoiceInformation is set.
+     * @return bool True if InvoiceInformation is set.
      */
     public function isSetInvoiceInformation()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrderItemsByNextTokenRequest.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrderItemsByNextTokenRequest.php
@@ -67,7 +67,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsByNextTokenRequest extends
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsByNextTokenRequest extends
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsByNextTokenRequest extends
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrderItemsByNextTokenResponse.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrderItemsByNextTokenResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsByNextTokenResponse extend
     /**
      * Check to see if ListOrderItemsByNextTokenResult is set.
      *
-     * @return true if ListOrderItemsByNextTokenResult is set.
+     * @return bool True if ListOrderItemsByNextTokenResult is set.
      */
     public function isSetListOrderItemsByNextTokenResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsByNextTokenResponse extend
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsByNextTokenResponse extend
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrderItemsByNextTokenResult.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrderItemsByNextTokenResult.php
@@ -71,7 +71,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsByNextTokenResult extends 
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -117,7 +117,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsByNextTokenResult extends 
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {
@@ -177,7 +177,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsByNextTokenResult extends 
     /**
      * Check to see if OrderItems is set.
      *
-     * @return true if OrderItems is set.
+     * @return bool True if OrderItems is set.
      */
     public function isSetOrderItems()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrderItemsRequest.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrderItemsRequest.php
@@ -67,7 +67,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsRequest extends Marketplac
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsRequest extends Marketplac
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsRequest extends Marketplac
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrderItemsResponse.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrderItemsResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsResponse extends Marketpla
     /**
      * Check to see if ListOrderItemsResult is set.
      *
-     * @return true if ListOrderItemsResult is set.
+     * @return bool True if ListOrderItemsResult is set.
      */
     public function isSetListOrderItemsResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsResponse extends Marketpla
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsResponse extends Marketpla
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrderItemsResult.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrderItemsResult.php
@@ -71,7 +71,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsResult extends Marketplace
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -117,7 +117,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsResult extends Marketplace
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {
@@ -177,7 +177,7 @@ class MarketplaceWebServiceOrders_Model_ListOrderItemsResult extends Marketplace
     /**
      * Check to see if OrderItems is set.
      *
-     * @return true if OrderItems is set.
+     * @return bool True if OrderItems is set.
      */
     public function isSetOrderItems()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrdersByNextTokenRequest.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrdersByNextTokenRequest.php
@@ -67,7 +67,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersByNextTokenRequest extends Mar
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersByNextTokenRequest extends Mar
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersByNextTokenRequest extends Mar
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrdersByNextTokenResponse.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrdersByNextTokenResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersByNextTokenResponse extends Ma
     /**
      * Check to see if ListOrdersByNextTokenResult is set.
      *
-     * @return true if ListOrdersByNextTokenResult is set.
+     * @return bool True if ListOrdersByNextTokenResult is set.
      */
     public function isSetListOrdersByNextTokenResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersByNextTokenResponse extends Ma
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersByNextTokenResponse extends Ma
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrdersByNextTokenResult.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrdersByNextTokenResult.php
@@ -73,7 +73,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersByNextTokenResult extends Mark
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -119,7 +119,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersByNextTokenResult extends Mark
     /**
      * Check to see if CreatedBefore is set.
      *
-     * @return true if CreatedBefore is set.
+     * @return bool True if CreatedBefore is set.
      */
     public function isSetCreatedBefore()
     {
@@ -165,7 +165,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersByNextTokenResult extends Mark
     /**
      * Check to see if LastUpdatedBefore is set.
      *
-     * @return true if LastUpdatedBefore is set.
+     * @return bool True if LastUpdatedBefore is set.
      */
     public function isSetLastUpdatedBefore()
     {
@@ -225,7 +225,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersByNextTokenResult extends Mark
     /**
      * Check to see if Orders is set.
      *
-     * @return true if Orders is set.
+     * @return bool True if Orders is set.
      */
     public function isSetOrders()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrdersRequest.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrdersRequest.php
@@ -105,7 +105,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -151,7 +151,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -197,7 +197,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if CreatedAfter is set.
      *
-     * @return true if CreatedAfter is set.
+     * @return bool True if CreatedAfter is set.
      */
     public function isSetCreatedAfter()
     {
@@ -243,7 +243,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if CreatedBefore is set.
      *
-     * @return true if CreatedBefore is set.
+     * @return bool True if CreatedBefore is set.
      */
     public function isSetCreatedBefore()
     {
@@ -289,7 +289,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if LastUpdatedAfter is set.
      *
-     * @return true if LastUpdatedAfter is set.
+     * @return bool True if LastUpdatedAfter is set.
      */
     public function isSetLastUpdatedAfter()
     {
@@ -335,7 +335,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if LastUpdatedBefore is set.
      *
-     * @return true if LastUpdatedBefore is set.
+     * @return bool True if LastUpdatedBefore is set.
      */
     public function isSetLastUpdatedBefore()
     {
@@ -395,7 +395,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if OrderStatus is set.
      *
-     * @return true if OrderStatus is set.
+     * @return bool True if OrderStatus is set.
      */
     public function isSetOrderStatus()
     {
@@ -457,7 +457,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -519,7 +519,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if FulfillmentChannel is set.
      *
-     * @return true if FulfillmentChannel is set.
+     * @return bool True if FulfillmentChannel is set.
      */
     public function isSetFulfillmentChannel()
     {
@@ -581,7 +581,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if PaymentMethod is set.
      *
-     * @return true if PaymentMethod is set.
+     * @return bool True if PaymentMethod is set.
      */
     public function isSetPaymentMethod()
     {
@@ -629,7 +629,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if BuyerEmail is set.
      *
-     * @return true if BuyerEmail is set.
+     * @return bool True if BuyerEmail is set.
      */
     public function isSetBuyerEmail()
     {
@@ -675,7 +675,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if SellerOrderId is set.
      *
-     * @return true if SellerOrderId is set.
+     * @return bool True if SellerOrderId is set.
      */
     public function isSetSellerOrderId()
     {
@@ -721,7 +721,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if MaxResultsPerPage is set.
      *
-     * @return true if MaxResultsPerPage is set.
+     * @return bool True if MaxResultsPerPage is set.
      */
     public function isSetMaxResultsPerPage()
     {
@@ -781,7 +781,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersRequest extends MarketplaceWeb
     /**
      * Check to see if TFMShipmentStatus is set.
      *
-     * @return true if TFMShipmentStatus is set.
+     * @return bool True if TFMShipmentStatus is set.
      */
     public function isSetTFMShipmentStatus()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrdersResponse.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrdersResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersResponse extends MarketplaceWe
     /**
      * Check to see if ListOrdersResult is set.
      *
-     * @return true if ListOrdersResult is set.
+     * @return bool True if ListOrdersResult is set.
      */
     public function isSetListOrdersResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersResponse extends MarketplaceWe
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersResponse extends MarketplaceWe
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ListOrdersResult.php
+++ b/src/MarketplaceWebServiceOrders/Model/ListOrdersResult.php
@@ -73,7 +73,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersResult extends MarketplaceWebS
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -119,7 +119,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersResult extends MarketplaceWebS
     /**
      * Check to see if CreatedBefore is set.
      *
-     * @return true if CreatedBefore is set.
+     * @return bool True if CreatedBefore is set.
      */
     public function isSetCreatedBefore()
     {
@@ -165,7 +165,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersResult extends MarketplaceWebS
     /**
      * Check to see if LastUpdatedBefore is set.
      *
-     * @return true if LastUpdatedBefore is set.
+     * @return bool True if LastUpdatedBefore is set.
      */
     public function isSetLastUpdatedBefore()
     {
@@ -225,7 +225,7 @@ class MarketplaceWebServiceOrders_Model_ListOrdersResult extends MarketplaceWebS
     /**
      * Check to see if Orders is set.
      *
-     * @return true if Orders is set.
+     * @return bool True if Orders is set.
      */
     public function isSetOrders()
     {

--- a/src/MarketplaceWebServiceOrders/Model/Message.php
+++ b/src/MarketplaceWebServiceOrders/Model/Message.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceOrders_Model_Message extends MarketplaceWebServiceOrd
     /**
      * Check to see if Locale is set.
      *
-     * @return true if Locale is set.
+     * @return bool True if Locale is set.
      */
     public function isSetLocale()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceOrders_Model_Message extends MarketplaceWebServiceOrd
     /**
      * Check to see if Text is set.
      *
-     * @return true if Text is set.
+     * @return bool True if Text is set.
      */
     public function isSetText()
     {

--- a/src/MarketplaceWebServiceOrders/Model/Money.php
+++ b/src/MarketplaceWebServiceOrders/Model/Money.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceOrders_Model_Money extends MarketplaceWebServiceOrder
     /**
      * Check to see if CurrencyCode is set.
      *
-     * @return true if CurrencyCode is set.
+     * @return bool True if CurrencyCode is set.
      */
     public function isSetCurrencyCode()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceOrders_Model_Money extends MarketplaceWebServiceOrder
     /**
      * Check to see if Amount is set.
      *
-     * @return true if Amount is set.
+     * @return bool True if Amount is set.
      */
     public function isSetAmount()
     {

--- a/src/MarketplaceWebServiceOrders/Model/Order.php
+++ b/src/MarketplaceWebServiceOrders/Model/Order.php
@@ -122,7 +122,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if AmazonOrderId is set.
      *
-     * @return true if AmazonOrderId is set.
+     * @return bool True if AmazonOrderId is set.
      */
     public function isSetAmazonOrderId()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if SellerOrderId is set.
      *
-     * @return true if SellerOrderId is set.
+     * @return bool True if SellerOrderId is set.
      */
     public function isSetSellerOrderId()
     {
@@ -214,7 +214,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if PurchaseDate is set.
      *
-     * @return true if PurchaseDate is set.
+     * @return bool True if PurchaseDate is set.
      */
     public function isSetPurchaseDate()
     {
@@ -260,7 +260,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if LastUpdateDate is set.
      *
-     * @return true if LastUpdateDate is set.
+     * @return bool True if LastUpdateDate is set.
      */
     public function isSetLastUpdateDate()
     {
@@ -306,7 +306,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if OrderStatus is set.
      *
-     * @return true if OrderStatus is set.
+     * @return bool True if OrderStatus is set.
      */
     public function isSetOrderStatus()
     {
@@ -352,7 +352,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if FulfillmentChannel is set.
      *
-     * @return true if FulfillmentChannel is set.
+     * @return bool True if FulfillmentChannel is set.
      */
     public function isSetFulfillmentChannel()
     {
@@ -398,7 +398,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if SalesChannel is set.
      *
-     * @return true if SalesChannel is set.
+     * @return bool True if SalesChannel is set.
      */
     public function isSetSalesChannel()
     {
@@ -444,7 +444,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if OrderChannel is set.
      *
-     * @return true if OrderChannel is set.
+     * @return bool True if OrderChannel is set.
      */
     public function isSetOrderChannel()
     {
@@ -490,7 +490,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if ShipServiceLevel is set.
      *
-     * @return true if ShipServiceLevel is set.
+     * @return bool True if ShipServiceLevel is set.
      */
     public function isSetShipServiceLevel()
     {
@@ -536,7 +536,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if ShippingAddress is set.
      *
-     * @return true if ShippingAddress is set.
+     * @return bool True if ShippingAddress is set.
      */
     public function isSetShippingAddress()
     {
@@ -582,7 +582,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if OrderTotal is set.
      *
-     * @return true if OrderTotal is set.
+     * @return bool True if OrderTotal is set.
      */
     public function isSetOrderTotal()
     {
@@ -628,7 +628,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if NumberOfItemsShipped is set.
      *
-     * @return true if NumberOfItemsShipped is set.
+     * @return bool True if NumberOfItemsShipped is set.
      */
     public function isSetNumberOfItemsShipped()
     {
@@ -674,7 +674,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if NumberOfItemsUnshipped is set.
      *
-     * @return true if NumberOfItemsUnshipped is set.
+     * @return bool True if NumberOfItemsUnshipped is set.
      */
     public function isSetNumberOfItemsUnshipped()
     {
@@ -734,7 +734,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if PaymentExecutionDetail is set.
      *
-     * @return true if PaymentExecutionDetail is set.
+     * @return bool True if PaymentExecutionDetail is set.
      */
     public function isSetPaymentExecutionDetail()
     {
@@ -782,7 +782,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if PaymentMethod is set.
      *
-     * @return true if PaymentMethod is set.
+     * @return bool True if PaymentMethod is set.
      */
     public function isSetPaymentMethod()
     {
@@ -828,7 +828,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -874,7 +874,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if BuyerEmail is set.
      *
-     * @return true if BuyerEmail is set.
+     * @return bool True if BuyerEmail is set.
      */
     public function isSetBuyerEmail()
     {
@@ -920,7 +920,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if BuyerName is set.
      *
-     * @return true if BuyerName is set.
+     * @return bool True if BuyerName is set.
      */
     public function isSetBuyerName()
     {
@@ -966,7 +966,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if ShipmentServiceLevelCategory is set.
      *
-     * @return true if ShipmentServiceLevelCategory is set.
+     * @return bool True if ShipmentServiceLevelCategory is set.
      */
     public function isSetShipmentServiceLevelCategory()
     {
@@ -990,7 +990,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check the value of ShippedByAmazonTFM.
      *
-     * @return true if ShippedByAmazonTFM is set to true.
+     * @return bool True if ShippedByAmazonTFM is set to true.
      */
     public function isShippedByAmazonTFM()
     {
@@ -1022,7 +1022,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if ShippedByAmazonTFM is set.
      *
-     * @return true if ShippedByAmazonTFM is set.
+     * @return bool True if ShippedByAmazonTFM is set.
      */
     public function isSetShippedByAmazonTFM()
     {
@@ -1068,7 +1068,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if TFMShipmentStatus is set.
      *
-     * @return true if TFMShipmentStatus is set.
+     * @return bool True if TFMShipmentStatus is set.
      */
     public function isSetTFMShipmentStatus()
     {
@@ -1114,7 +1114,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if CbaDisplayableShippingLabel is set.
      *
-     * @return true if CbaDisplayableShippingLabel is set.
+     * @return bool True if CbaDisplayableShippingLabel is set.
      */
     public function isSetCbaDisplayableShippingLabel()
     {
@@ -1160,7 +1160,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if OrderType is set.
      *
-     * @return true if OrderType is set.
+     * @return bool True if OrderType is set.
      */
     public function isSetOrderType()
     {
@@ -1206,7 +1206,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if EarliestShipDate is set.
      *
-     * @return true if EarliestShipDate is set.
+     * @return bool True if EarliestShipDate is set.
      */
     public function isSetEarliestShipDate()
     {
@@ -1252,7 +1252,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if LatestShipDate is set.
      *
-     * @return true if LatestShipDate is set.
+     * @return bool True if LatestShipDate is set.
      */
     public function isSetLatestShipDate()
     {
@@ -1298,7 +1298,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if EarliestDeliveryDate is set.
      *
-     * @return true if EarliestDeliveryDate is set.
+     * @return bool True if EarliestDeliveryDate is set.
      */
     public function isSetEarliestDeliveryDate()
     {
@@ -1344,7 +1344,7 @@ class MarketplaceWebServiceOrders_Model_Order extends MarketplaceWebServiceOrder
     /**
      * Check to see if LatestDeliveryDate is set.
      *
-     * @return true if LatestDeliveryDate is set.
+     * @return bool True if LatestDeliveryDate is set.
      */
     public function isSetLatestDeliveryDate()
     {

--- a/src/MarketplaceWebServiceOrders/Model/OrderItem.php
+++ b/src/MarketplaceWebServiceOrders/Model/OrderItem.php
@@ -121,7 +121,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {
@@ -167,7 +167,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -213,7 +213,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if OrderItemId is set.
      *
-     * @return true if OrderItemId is set.
+     * @return bool True if OrderItemId is set.
      */
     public function isSetOrderItemId()
     {
@@ -259,7 +259,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if Title is set.
      *
-     * @return true if Title is set.
+     * @return bool True if Title is set.
      */
     public function isSetTitle()
     {
@@ -305,7 +305,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if QuantityOrdered is set.
      *
-     * @return true if QuantityOrdered is set.
+     * @return bool True if QuantityOrdered is set.
      */
     public function isSetQuantityOrdered()
     {
@@ -351,7 +351,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if QuantityShipped is set.
      *
-     * @return true if QuantityShipped is set.
+     * @return bool True if QuantityShipped is set.
      */
     public function isSetQuantityShipped()
     {
@@ -397,7 +397,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if ItemPrice is set.
      *
-     * @return true if ItemPrice is set.
+     * @return bool True if ItemPrice is set.
      */
     public function isSetItemPrice()
     {
@@ -443,7 +443,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if ShippingPrice is set.
      *
-     * @return true if ShippingPrice is set.
+     * @return bool True if ShippingPrice is set.
      */
     public function isSetShippingPrice()
     {
@@ -489,7 +489,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if GiftWrapPrice is set.
      *
-     * @return true if GiftWrapPrice is set.
+     * @return bool True if GiftWrapPrice is set.
      */
     public function isSetGiftWrapPrice()
     {
@@ -535,7 +535,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if ItemTax is set.
      *
-     * @return true if ItemTax is set.
+     * @return bool True if ItemTax is set.
      */
     public function isSetItemTax()
     {
@@ -581,7 +581,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if ShippingTax is set.
      *
-     * @return true if ShippingTax is set.
+     * @return bool True if ShippingTax is set.
      */
     public function isSetShippingTax()
     {
@@ -627,7 +627,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if GiftWrapTax is set.
      *
-     * @return true if GiftWrapTax is set.
+     * @return bool True if GiftWrapTax is set.
      */
     public function isSetGiftWrapTax()
     {
@@ -673,7 +673,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if ShippingDiscount is set.
      *
-     * @return true if ShippingDiscount is set.
+     * @return bool True if ShippingDiscount is set.
      */
     public function isSetShippingDiscount()
     {
@@ -719,7 +719,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if PromotionDiscount is set.
      *
-     * @return true if PromotionDiscount is set.
+     * @return bool True if PromotionDiscount is set.
      */
     public function isSetPromotionDiscount()
     {
@@ -779,7 +779,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if PromotionIds is set.
      *
-     * @return true if PromotionIds is set.
+     * @return bool True if PromotionIds is set.
      */
     public function isSetPromotionIds()
     {
@@ -827,7 +827,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if CODFee is set.
      *
-     * @return true if CODFee is set.
+     * @return bool True if CODFee is set.
      */
     public function isSetCODFee()
     {
@@ -873,7 +873,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if CODFeeDiscount is set.
      *
-     * @return true if CODFeeDiscount is set.
+     * @return bool True if CODFeeDiscount is set.
      */
     public function isSetCODFeeDiscount()
     {
@@ -919,7 +919,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if GiftMessageText is set.
      *
-     * @return true if GiftMessageText is set.
+     * @return bool True if GiftMessageText is set.
      */
     public function isSetGiftMessageText()
     {
@@ -965,7 +965,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if GiftWrapLevel is set.
      *
-     * @return true if GiftWrapLevel is set.
+     * @return bool True if GiftWrapLevel is set.
      */
     public function isSetGiftWrapLevel()
     {
@@ -1011,7 +1011,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if InvoiceData is set.
      *
-     * @return true if InvoiceData is set.
+     * @return bool True if InvoiceData is set.
      */
     public function isSetInvoiceData()
     {
@@ -1057,7 +1057,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if ConditionNote is set.
      *
-     * @return true if ConditionNote is set.
+     * @return bool True if ConditionNote is set.
      */
     public function isSetConditionNote()
     {
@@ -1103,7 +1103,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if ConditionId is set.
      *
-     * @return true if ConditionId is set.
+     * @return bool True if ConditionId is set.
      */
     public function isSetConditionId()
     {
@@ -1149,7 +1149,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if ConditionSubtypeId is set.
      *
-     * @return true if ConditionSubtypeId is set.
+     * @return bool True if ConditionSubtypeId is set.
      */
     public function isSetConditionSubtypeId()
     {
@@ -1195,7 +1195,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if ScheduledDeliveryStartDate is set.
      *
-     * @return true if ScheduledDeliveryStartDate is set.
+     * @return bool True if ScheduledDeliveryStartDate is set.
      */
     public function isSetScheduledDeliveryStartDate()
     {
@@ -1241,7 +1241,7 @@ class MarketplaceWebServiceOrders_Model_OrderItem extends MarketplaceWebServiceO
     /**
      * Check to see if ScheduledDeliveryEndDate is set.
      *
-     * @return true if ScheduledDeliveryEndDate is set.
+     * @return bool True if ScheduledDeliveryEndDate is set.
      */
     public function isSetScheduledDeliveryEndDate()
     {

--- a/src/MarketplaceWebServiceOrders/Model/PaymentExecutionDetailItem.php
+++ b/src/MarketplaceWebServiceOrders/Model/PaymentExecutionDetailItem.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceOrders_Model_PaymentExecutionDetailItem extends Marke
     /**
      * Check to see if Payment is set.
      *
-     * @return true if Payment is set.
+     * @return bool True if Payment is set.
      */
     public function isSetPayment()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceOrders_Model_PaymentExecutionDetailItem extends Marke
     /**
      * Check to see if PaymentMethod is set.
      *
-     * @return true if PaymentMethod is set.
+     * @return bool True if PaymentMethod is set.
      */
     public function isSetPaymentMethod()
     {

--- a/src/MarketplaceWebServiceOrders/Model/ResponseMetadata.php
+++ b/src/MarketplaceWebServiceOrders/Model/ResponseMetadata.php
@@ -63,7 +63,7 @@ class MarketplaceWebServiceOrders_Model_ResponseMetadata extends MarketplaceWebS
     /**
      * Check to see if RequestId is set.
      *
-     * @return true if RequestId is set.
+     * @return bool True if RequestId is set.
      */
     public function isSetRequestId()
     {

--- a/src/MarketplaceWebServiceProducts/Model.php
+++ b/src/MarketplaceWebServiceProducts/Model.php
@@ -404,7 +404,7 @@ abstract class MarketplaceWebServiceProducts_Model
      * Checks  whether passed variable is an associative array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an associative array
+     * @return bool True if passed variable is an associative array
      */
     private function _isAssociativeArray($var)
     {
@@ -415,7 +415,7 @@ abstract class MarketplaceWebServiceProducts_Model
      * Checks  whether passed variable is DOMElement
      *
      * @param mixed $var
-     * @return TRUE if passed variable is DOMElement
+     * @return bool True if passed variable is DOMElement
      */
     private function _isDOMElement($var)
     {
@@ -426,7 +426,7 @@ abstract class MarketplaceWebServiceProducts_Model
      * Checks  whether passed variable is numeric array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an numeric array
+     * @return bool True if passed variable is an numeric array
      */
     protected function _isNumericArray($var)
     {

--- a/src/MarketplaceWebServiceProducts/Model/ASINIdentifier.php
+++ b/src/MarketplaceWebServiceProducts/Model/ASINIdentifier.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceProducts_Model_ASINIdentifier extends MarketplaceWebS
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceProducts_Model_ASINIdentifier extends MarketplaceWebS
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {

--- a/src/MarketplaceWebServiceProducts/Model/ASINListType.php
+++ b/src/MarketplaceWebServiceProducts/Model/ASINListType.php
@@ -77,7 +77,7 @@ class MarketplaceWebServiceProducts_Model_ASINListType extends MarketplaceWebSer
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {

--- a/src/MarketplaceWebServiceProducts/Model/AttributeSetList.php
+++ b/src/MarketplaceWebServiceProducts/Model/AttributeSetList.php
@@ -77,7 +77,7 @@ class MarketplaceWebServiceProducts_Model_AttributeSetList extends MarketplaceWe
     /**
      * Check to see if Any is set.
      *
-     * @return true if Any is set.
+     * @return bool True if Any is set.
      */
     public function isSetAny()
     {

--- a/src/MarketplaceWebServiceProducts/Model/Categories.php
+++ b/src/MarketplaceWebServiceProducts/Model/Categories.php
@@ -67,7 +67,7 @@ class MarketplaceWebServiceProducts_Model_Categories extends MarketplaceWebServi
     /**
      * Check to see if ProductCategoryId is set.
      *
-     * @return true if ProductCategoryId is set.
+     * @return bool True if ProductCategoryId is set.
      */
     public function isSetProductCategoryId()
     {
@@ -113,7 +113,7 @@ class MarketplaceWebServiceProducts_Model_Categories extends MarketplaceWebServi
     /**
      * Check to see if ProductCategoryName is set.
      *
-     * @return true if ProductCategoryName is set.
+     * @return bool True if ProductCategoryName is set.
      */
     public function isSetProductCategoryName()
     {
@@ -159,7 +159,7 @@ class MarketplaceWebServiceProducts_Model_Categories extends MarketplaceWebServi
     /**
      * Check to see if Parent is set.
      *
-     * @return true if Parent is set.
+     * @return bool True if Parent is set.
      */
     public function isSetParent()
     {

--- a/src/MarketplaceWebServiceProducts/Model/CompetitivePriceList.php
+++ b/src/MarketplaceWebServiceProducts/Model/CompetitivePriceList.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceProducts_Model_CompetitivePriceList extends Marketpla
     /**
      * Check to see if CompetitivePrice is set.
      *
-     * @return true if CompetitivePrice is set.
+     * @return bool True if CompetitivePrice is set.
      */
     public function isSetCompetitivePrice()
     {

--- a/src/MarketplaceWebServiceProducts/Model/CompetitivePriceType.php
+++ b/src/MarketplaceWebServiceProducts/Model/CompetitivePriceType.php
@@ -71,7 +71,7 @@ class MarketplaceWebServiceProducts_Model_CompetitivePriceType extends Marketpla
     /**
      * Check to see if CompetitivePriceId is set.
      *
-     * @return true if CompetitivePriceId is set.
+     * @return bool True if CompetitivePriceId is set.
      */
     public function isSetCompetitivePriceId()
     {
@@ -117,7 +117,7 @@ class MarketplaceWebServiceProducts_Model_CompetitivePriceType extends Marketpla
     /**
      * Check to see if Price is set.
      *
-     * @return true if Price is set.
+     * @return bool True if Price is set.
      */
     public function isSetPrice()
     {
@@ -163,7 +163,7 @@ class MarketplaceWebServiceProducts_Model_CompetitivePriceType extends Marketpla
     /**
      * Check to see if condition is set.
      *
-     * @return true if condition is set.
+     * @return bool True if condition is set.
      */
     public function isSetcondition()
     {
@@ -209,7 +209,7 @@ class MarketplaceWebServiceProducts_Model_CompetitivePriceType extends Marketpla
     /**
      * Check to see if subcondition is set.
      *
-     * @return true if subcondition is set.
+     * @return bool True if subcondition is set.
      */
     public function isSetsubcondition()
     {
@@ -233,7 +233,7 @@ class MarketplaceWebServiceProducts_Model_CompetitivePriceType extends Marketpla
     /**
      * Check the value of belongsToRequester.
      *
-     * @return true if belongsToRequester is set to true.
+     * @return bool True if belongsToRequester is set to true.
      */
     public function isbelongsToRequester()
     {
@@ -265,7 +265,7 @@ class MarketplaceWebServiceProducts_Model_CompetitivePriceType extends Marketpla
     /**
      * Check to see if belongsToRequester is set.
      *
-     * @return true if belongsToRequester is set.
+     * @return bool True if belongsToRequester is set.
      */
     public function isSetbelongsToRequester()
     {

--- a/src/MarketplaceWebServiceProducts/Model/CompetitivePricingType.php
+++ b/src/MarketplaceWebServiceProducts/Model/CompetitivePricingType.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceProducts_Model_CompetitivePricingType extends Marketp
     /**
      * Check to see if CompetitivePrices is set.
      *
-     * @return true if CompetitivePrices is set.
+     * @return bool True if CompetitivePrices is set.
      */
     public function isSetCompetitivePrices()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceProducts_Model_CompetitivePricingType extends Marketp
     /**
      * Check to see if NumberOfOfferListings is set.
      *
-     * @return true if NumberOfOfferListings is set.
+     * @return bool True if NumberOfOfferListings is set.
      */
     public function isSetNumberOfOfferListings()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceProducts_Model_CompetitivePricingType extends Marketp
     /**
      * Check to see if TradeInValue is set.
      *
-     * @return true if TradeInValue is set.
+     * @return bool True if TradeInValue is set.
      */
     public function isSetTradeInValue()
     {

--- a/src/MarketplaceWebServiceProducts/Model/Error.php
+++ b/src/MarketplaceWebServiceProducts/Model/Error.php
@@ -69,7 +69,7 @@ class MarketplaceWebServiceProducts_Model_Error extends MarketplaceWebServicePro
     /**
      * Check to see if Type is set.
      *
-     * @return true if Type is set.
+     * @return bool True if Type is set.
      */
     public function isSetType()
     {
@@ -115,7 +115,7 @@ class MarketplaceWebServiceProducts_Model_Error extends MarketplaceWebServicePro
     /**
      * Check to see if Code is set.
      *
-     * @return true if Code is set.
+     * @return bool True if Code is set.
      */
     public function isSetCode()
     {
@@ -161,7 +161,7 @@ class MarketplaceWebServiceProducts_Model_Error extends MarketplaceWebServicePro
     /**
      * Check to see if Message is set.
      *
-     * @return true if Message is set.
+     * @return bool True if Message is set.
      */
     public function isSetMessage()
     {
@@ -207,7 +207,7 @@ class MarketplaceWebServiceProducts_Model_Error extends MarketplaceWebServicePro
     /**
      * Check to see if Detail is set.
      *
-     * @return true if Detail is set.
+     * @return bool True if Detail is set.
      */
     public function isSetDetail()
     {

--- a/src/MarketplaceWebServiceProducts/Model/ErrorDetail.php
+++ b/src/MarketplaceWebServiceProducts/Model/ErrorDetail.php
@@ -77,7 +77,7 @@ class MarketplaceWebServiceProducts_Model_ErrorDetail extends MarketplaceWebServ
     /**
      * Check to see if Any is set.
      *
-     * @return true if Any is set.
+     * @return bool True if Any is set.
      */
     public function isSetAny()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForASINRequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForASINRequest.php
@@ -72,7 +72,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForASINRequest ex
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -118,7 +118,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForASINRequest ex
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -164,7 +164,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForASINRequest ex
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -210,7 +210,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForASINRequest ex
     /**
      * Check to see if ASINList is set.
      *
-     * @return true if ASINList is set.
+     * @return bool True if ASINList is set.
      */
     public function isSetASINList()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForASINResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForASINResponse.php
@@ -90,7 +90,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForASINResponse e
     /**
      * Check to see if GetCompetitivePricingForASINResult is set.
      *
-     * @return true if GetCompetitivePricingForASINResult is set.
+     * @return bool True if GetCompetitivePricingForASINResult is set.
      */
     public function isSetGetCompetitivePricingForASINResult()
     {
@@ -138,7 +138,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForASINResponse e
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -184,7 +184,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForASINResponse e
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForASINResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForASINResult.php
@@ -69,7 +69,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForASINResult ext
     /**
      * Check to see if Product is set.
      *
-     * @return true if Product is set.
+     * @return bool True if Product is set.
      */
     public function isSetProduct()
     {
@@ -115,7 +115,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForASINResult ext
     /**
      * Check to see if Error is set.
      *
-     * @return true if Error is set.
+     * @return bool True if Error is set.
      */
     public function isSetError()
     {
@@ -161,7 +161,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForASINResult ext
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {
@@ -207,7 +207,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForASINResult ext
     /**
      * Check to see if status is set.
      *
-     * @return true if status is set.
+     * @return bool True if status is set.
      */
     public function isSetstatus()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForSKURequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForSKURequest.php
@@ -72,7 +72,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForSKURequest ext
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -118,7 +118,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForSKURequest ext
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -164,7 +164,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForSKURequest ext
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -210,7 +210,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForSKURequest ext
     /**
      * Check to see if SellerSKUList is set.
      *
-     * @return true if SellerSKUList is set.
+     * @return bool True if SellerSKUList is set.
      */
     public function isSetSellerSKUList()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForSKUResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForSKUResponse.php
@@ -90,7 +90,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForSKUResponse ex
     /**
      * Check to see if GetCompetitivePricingForSKUResult is set.
      *
-     * @return true if GetCompetitivePricingForSKUResult is set.
+     * @return bool True if GetCompetitivePricingForSKUResult is set.
      */
     public function isSetGetCompetitivePricingForSKUResult()
     {
@@ -138,7 +138,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForSKUResponse ex
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -184,7 +184,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForSKUResponse ex
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForSKUResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetCompetitivePricingForSKUResult.php
@@ -69,7 +69,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForSKUResult exte
     /**
      * Check to see if Product is set.
      *
-     * @return true if Product is set.
+     * @return bool True if Product is set.
      */
     public function isSetProduct()
     {
@@ -115,7 +115,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForSKUResult exte
     /**
      * Check to see if Error is set.
      *
-     * @return true if Error is set.
+     * @return bool True if Error is set.
      */
     public function isSetError()
     {
@@ -161,7 +161,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForSKUResult exte
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -207,7 +207,7 @@ class MarketplaceWebServiceProducts_Model_GetCompetitivePricingForSKUResult exte
     /**
      * Check to see if status is set.
      *
-     * @return true if status is set.
+     * @return bool True if status is set.
      */
     public function isSetstatus()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForASINRequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForASINRequest.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINRequest e
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINRequest e
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINRequest e
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -214,7 +214,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINRequest e
     /**
      * Check to see if ASINList is set.
      *
-     * @return true if ASINList is set.
+     * @return bool True if ASINList is set.
      */
     public function isSetASINList()
     {
@@ -260,7 +260,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINRequest e
     /**
      * Check to see if ItemCondition is set.
      *
-     * @return true if ItemCondition is set.
+     * @return bool True if ItemCondition is set.
      */
     public function isSetItemCondition()
     {
@@ -284,7 +284,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINRequest e
     /**
      * Check the value of ExcludeMe.
      *
-     * @return true if ExcludeMe is set to true.
+     * @return bool True if ExcludeMe is set to true.
      */
     public function isExcludeMe()
     {
@@ -316,7 +316,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINRequest e
     /**
      * Check to see if ExcludeMe is set.
      *
-     * @return true if ExcludeMe is set.
+     * @return bool True if ExcludeMe is set.
      */
     public function isSetExcludeMe()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForASINResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForASINResponse.php
@@ -90,7 +90,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINResponse 
     /**
      * Check to see if GetLowestOfferListingsForASINResult is set.
      *
-     * @return true if GetLowestOfferListingsForASINResult is set.
+     * @return bool True if GetLowestOfferListingsForASINResult is set.
      */
     public function isSetGetLowestOfferListingsForASINResult()
     {
@@ -138,7 +138,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINResponse 
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -184,7 +184,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINResponse 
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForASINResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForASINResult.php
@@ -49,7 +49,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINResult ex
     /**
      * Check the value of AllOfferListingsConsidered.
      *
-     * @return true if AllOfferListingsConsidered is set to true.
+     * @return bool True if AllOfferListingsConsidered is set to true.
      */
     public function isAllOfferListingsConsidered()
     {
@@ -81,7 +81,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINResult ex
     /**
      * Check to see if AllOfferListingsConsidered is set.
      *
-     * @return true if AllOfferListingsConsidered is set.
+     * @return bool True if AllOfferListingsConsidered is set.
      */
     public function isSetAllOfferListingsConsidered()
     {
@@ -127,7 +127,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINResult ex
     /**
      * Check to see if Product is set.
      *
-     * @return true if Product is set.
+     * @return bool True if Product is set.
      */
     public function isSetProduct()
     {
@@ -173,7 +173,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINResult ex
     /**
      * Check to see if Error is set.
      *
-     * @return true if Error is set.
+     * @return bool True if Error is set.
      */
     public function isSetError()
     {
@@ -219,7 +219,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINResult ex
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {
@@ -265,7 +265,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForASINResult ex
     /**
      * Check to see if status is set.
      *
-     * @return true if status is set.
+     * @return bool True if status is set.
      */
     public function isSetstatus()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForSKURequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForSKURequest.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKURequest ex
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKURequest ex
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKURequest ex
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -214,7 +214,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKURequest ex
     /**
      * Check to see if SellerSKUList is set.
      *
-     * @return true if SellerSKUList is set.
+     * @return bool True if SellerSKUList is set.
      */
     public function isSetSellerSKUList()
     {
@@ -260,7 +260,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKURequest ex
     /**
      * Check to see if ItemCondition is set.
      *
-     * @return true if ItemCondition is set.
+     * @return bool True if ItemCondition is set.
      */
     public function isSetItemCondition()
     {
@@ -284,7 +284,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKURequest ex
     /**
      * Check the value of ExcludeMe.
      *
-     * @return true if ExcludeMe is set to true.
+     * @return bool True if ExcludeMe is set to true.
      */
     public function isExcludeMe()
     {
@@ -316,7 +316,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKURequest ex
     /**
      * Check to see if ExcludeMe is set.
      *
-     * @return true if ExcludeMe is set.
+     * @return bool True if ExcludeMe is set.
      */
     public function isSetExcludeMe()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForSKUResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForSKUResponse.php
@@ -90,7 +90,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKUResponse e
     /**
      * Check to see if GetLowestOfferListingsForSKUResult is set.
      *
-     * @return true if GetLowestOfferListingsForSKUResult is set.
+     * @return bool True if GetLowestOfferListingsForSKUResult is set.
      */
     public function isSetGetLowestOfferListingsForSKUResult()
     {
@@ -138,7 +138,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKUResponse e
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -184,7 +184,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKUResponse e
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForSKUResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetLowestOfferListingsForSKUResult.php
@@ -49,7 +49,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKUResult ext
     /**
      * Check the value of AllOfferListingsConsidered.
      *
-     * @return true if AllOfferListingsConsidered is set to true.
+     * @return bool True if AllOfferListingsConsidered is set to true.
      */
     public function isAllOfferListingsConsidered()
     {
@@ -81,7 +81,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKUResult ext
     /**
      * Check to see if AllOfferListingsConsidered is set.
      *
-     * @return true if AllOfferListingsConsidered is set.
+     * @return bool True if AllOfferListingsConsidered is set.
      */
     public function isSetAllOfferListingsConsidered()
     {
@@ -127,7 +127,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKUResult ext
     /**
      * Check to see if Product is set.
      *
-     * @return true if Product is set.
+     * @return bool True if Product is set.
      */
     public function isSetProduct()
     {
@@ -173,7 +173,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKUResult ext
     /**
      * Check to see if Error is set.
      *
-     * @return true if Error is set.
+     * @return bool True if Error is set.
      */
     public function isSetError()
     {
@@ -219,7 +219,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKUResult ext
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -265,7 +265,7 @@ class MarketplaceWebServiceProducts_Model_GetLowestOfferListingsForSKUResult ext
     /**
      * Check to see if status is set.
      *
-     * @return true if status is set.
+     * @return bool True if status is set.
      */
     public function isSetstatus()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMatchingProductForIdRequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMatchingProductForIdRequest.php
@@ -71,7 +71,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdRequest extends
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -117,7 +117,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdRequest extends
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -163,7 +163,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdRequest extends
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -209,7 +209,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdRequest extends
     /**
      * Check to see if IdType is set.
      *
-     * @return true if IdType is set.
+     * @return bool True if IdType is set.
      */
     public function isSetIdType()
     {
@@ -255,7 +255,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdRequest extends
     /**
      * Check to see if IdList is set.
      *
-     * @return true if IdList is set.
+     * @return bool True if IdList is set.
      */
     public function isSetIdList()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMatchingProductForIdResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMatchingProductForIdResponse.php
@@ -90,7 +90,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdResponse extend
     /**
      * Check to see if GetMatchingProductForIdResult is set.
      *
-     * @return true if GetMatchingProductForIdResult is set.
+     * @return bool True if GetMatchingProductForIdResult is set.
      */
     public function isSetGetMatchingProductForIdResult()
     {
@@ -138,7 +138,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdResponse extend
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -184,7 +184,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdResponse extend
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMatchingProductForIdResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMatchingProductForIdResult.php
@@ -71,7 +71,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdResult extends 
     /**
      * Check to see if Products is set.
      *
-     * @return true if Products is set.
+     * @return bool True if Products is set.
      */
     public function isSetProducts()
     {
@@ -117,7 +117,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdResult extends 
     /**
      * Check to see if Error is set.
      *
-     * @return true if Error is set.
+     * @return bool True if Error is set.
      */
     public function isSetError()
     {
@@ -163,7 +163,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdResult extends 
     /**
      * Check to see if Id is set.
      *
-     * @return true if Id is set.
+     * @return bool True if Id is set.
      */
     public function isSetId()
     {
@@ -209,7 +209,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdResult extends 
     /**
      * Check to see if IdType is set.
      *
-     * @return true if IdType is set.
+     * @return bool True if IdType is set.
      */
     public function isSetIdType()
     {
@@ -255,7 +255,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductForIdResult extends 
     /**
      * Check to see if status is set.
      *
-     * @return true if status is set.
+     * @return bool True if status is set.
      */
     public function isSetstatus()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMatchingProductRequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMatchingProductRequest.php
@@ -72,7 +72,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductRequest extends Mark
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -118,7 +118,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductRequest extends Mark
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -164,7 +164,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductRequest extends Mark
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -210,7 +210,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductRequest extends Mark
     /**
      * Check to see if ASINList is set.
      *
-     * @return true if ASINList is set.
+     * @return bool True if ASINList is set.
      */
     public function isSetASINList()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMatchingProductResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMatchingProductResponse.php
@@ -90,7 +90,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductResponse extends Mar
     /**
      * Check to see if GetMatchingProductResult is set.
      *
-     * @return true if GetMatchingProductResult is set.
+     * @return bool True if GetMatchingProductResult is set.
      */
     public function isSetGetMatchingProductResult()
     {
@@ -138,7 +138,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductResponse extends Mar
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -184,7 +184,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductResponse extends Mar
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMatchingProductResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMatchingProductResult.php
@@ -69,7 +69,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductResult extends Marke
     /**
      * Check to see if Product is set.
      *
-     * @return true if Product is set.
+     * @return bool True if Product is set.
      */
     public function isSetProduct()
     {
@@ -115,7 +115,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductResult extends Marke
     /**
      * Check to see if Error is set.
      *
-     * @return true if Error is set.
+     * @return bool True if Error is set.
      */
     public function isSetError()
     {
@@ -161,7 +161,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductResult extends Marke
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {
@@ -207,7 +207,7 @@ class MarketplaceWebServiceProducts_Model_GetMatchingProductResult extends Marke
     /**
      * Check to see if status is set.
      *
-     * @return true if status is set.
+     * @return bool True if status is set.
      */
     public function isSetstatus()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMyPriceForASINRequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMyPriceForASINRequest.php
@@ -72,7 +72,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForASINRequest extends Marke
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -118,7 +118,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForASINRequest extends Marke
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -164,7 +164,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForASINRequest extends Marke
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -210,7 +210,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForASINRequest extends Marke
     /**
      * Check to see if ASINList is set.
      *
-     * @return true if ASINList is set.
+     * @return bool True if ASINList is set.
      */
     public function isSetASINList()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMyPriceForASINResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMyPriceForASINResponse.php
@@ -90,7 +90,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForASINResponse extends Mark
     /**
      * Check to see if GetMyPriceForASINResult is set.
      *
-     * @return true if GetMyPriceForASINResult is set.
+     * @return bool True if GetMyPriceForASINResult is set.
      */
     public function isSetGetMyPriceForASINResult()
     {
@@ -138,7 +138,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForASINResponse extends Mark
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -184,7 +184,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForASINResponse extends Mark
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMyPriceForASINResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMyPriceForASINResult.php
@@ -69,7 +69,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForASINResult extends Market
     /**
      * Check to see if Product is set.
      *
-     * @return true if Product is set.
+     * @return bool True if Product is set.
      */
     public function isSetProduct()
     {
@@ -115,7 +115,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForASINResult extends Market
     /**
      * Check to see if Error is set.
      *
-     * @return true if Error is set.
+     * @return bool True if Error is set.
      */
     public function isSetError()
     {
@@ -161,7 +161,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForASINResult extends Market
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {
@@ -207,7 +207,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForASINResult extends Market
     /**
      * Check to see if status is set.
      *
-     * @return true if status is set.
+     * @return bool True if status is set.
      */
     public function isSetstatus()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMyPriceForSKURequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMyPriceForSKURequest.php
@@ -72,7 +72,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForSKURequest extends Market
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -118,7 +118,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForSKURequest extends Market
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -164,7 +164,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForSKURequest extends Market
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -210,7 +210,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForSKURequest extends Market
     /**
      * Check to see if SellerSKUList is set.
      *
-     * @return true if SellerSKUList is set.
+     * @return bool True if SellerSKUList is set.
      */
     public function isSetSellerSKUList()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMyPriceForSKUResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMyPriceForSKUResponse.php
@@ -90,7 +90,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForSKUResponse extends Marke
     /**
      * Check to see if GetMyPriceForSKUResult is set.
      *
-     * @return true if GetMyPriceForSKUResult is set.
+     * @return bool True if GetMyPriceForSKUResult is set.
      */
     public function isSetGetMyPriceForSKUResult()
     {
@@ -138,7 +138,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForSKUResponse extends Marke
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -184,7 +184,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForSKUResponse extends Marke
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetMyPriceForSKUResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetMyPriceForSKUResult.php
@@ -69,7 +69,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForSKUResult extends Marketp
     /**
      * Check to see if Product is set.
      *
-     * @return true if Product is set.
+     * @return bool True if Product is set.
      */
     public function isSetProduct()
     {
@@ -115,7 +115,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForSKUResult extends Marketp
     /**
      * Check to see if Error is set.
      *
-     * @return true if Error is set.
+     * @return bool True if Error is set.
      */
     public function isSetError()
     {
@@ -161,7 +161,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForSKUResult extends Marketp
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {
@@ -207,7 +207,7 @@ class MarketplaceWebServiceProducts_Model_GetMyPriceForSKUResult extends Marketp
     /**
      * Check to see if status is set.
      *
-     * @return true if status is set.
+     * @return bool True if status is set.
      */
     public function isSetstatus()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForASINRequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForASINRequest.php
@@ -69,7 +69,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForASINRequest ext
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -115,7 +115,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForASINRequest ext
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -161,7 +161,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForASINRequest ext
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -207,7 +207,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForASINRequest ext
     /**
      * Check to see if ASIN is set.
      *
-     * @return true if ASIN is set.
+     * @return bool True if ASIN is set.
      */
     public function isSetASIN()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForASINResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForASINResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForASINResponse ex
     /**
      * Check to see if GetProductCategoriesForASINResult is set.
      *
-     * @return true if GetProductCategoriesForASINResult is set.
+     * @return bool True if GetProductCategoriesForASINResult is set.
      */
     public function isSetGetProductCategoriesForASINResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForASINResponse ex
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForASINResponse ex
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForASINResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForASINResult.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForASINResult exte
     /**
      * Check to see if Self is set.
      *
-     * @return true if Self is set.
+     * @return bool True if Self is set.
      */
     public function isSetSelf()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForSKURequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForSKURequest.php
@@ -69,7 +69,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForSKURequest exte
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -115,7 +115,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForSKURequest exte
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -161,7 +161,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForSKURequest exte
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -207,7 +207,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForSKURequest exte
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForSKUResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForSKUResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForSKUResponse ext
     /**
      * Check to see if GetProductCategoriesForSKUResult is set.
      *
-     * @return true if GetProductCategoriesForSKUResult is set.
+     * @return bool True if GetProductCategoriesForSKUResult is set.
      */
     public function isSetGetProductCategoriesForSKUResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForSKUResponse ext
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForSKUResponse ext
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForSKUResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetProductCategoriesForSKUResult.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceProducts_Model_GetProductCategoriesForSKUResult exten
     /**
      * Check to see if Self is set.
      *
-     * @return true if Self is set.
+     * @return bool True if Self is set.
      */
     public function isSetSelf()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetServiceStatusRequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetServiceStatusRequest.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceProducts_Model_GetServiceStatusRequest extends Market
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceProducts_Model_GetServiceStatusRequest extends Market
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetServiceStatusResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetServiceStatusResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceProducts_Model_GetServiceStatusResponse extends Marke
     /**
      * Check to see if GetServiceStatusResult is set.
      *
-     * @return true if GetServiceStatusResult is set.
+     * @return bool True if GetServiceStatusResult is set.
      */
     public function isSetGetServiceStatusResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceProducts_Model_GetServiceStatusResponse extends Marke
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceProducts_Model_GetServiceStatusResponse extends Marke
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/GetServiceStatusResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/GetServiceStatusResult.php
@@ -69,7 +69,7 @@ class MarketplaceWebServiceProducts_Model_GetServiceStatusResult extends Marketp
     /**
      * Check to see if Status is set.
      *
-     * @return true if Status is set.
+     * @return bool True if Status is set.
      */
     public function isSetStatus()
     {
@@ -115,7 +115,7 @@ class MarketplaceWebServiceProducts_Model_GetServiceStatusResult extends Marketp
     /**
      * Check to see if Timestamp is set.
      *
-     * @return true if Timestamp is set.
+     * @return bool True if Timestamp is set.
      */
     public function isSetTimestamp()
     {
@@ -161,7 +161,7 @@ class MarketplaceWebServiceProducts_Model_GetServiceStatusResult extends Marketp
     /**
      * Check to see if MessageId is set.
      *
-     * @return true if MessageId is set.
+     * @return bool True if MessageId is set.
      */
     public function isSetMessageId()
     {
@@ -207,7 +207,7 @@ class MarketplaceWebServiceProducts_Model_GetServiceStatusResult extends Marketp
     /**
      * Check to see if Messages is set.
      *
-     * @return true if Messages is set.
+     * @return bool True if Messages is set.
      */
     public function isSetMessages()
     {

--- a/src/MarketplaceWebServiceProducts/Model/IdListType.php
+++ b/src/MarketplaceWebServiceProducts/Model/IdListType.php
@@ -77,7 +77,7 @@ class MarketplaceWebServiceProducts_Model_IdListType extends MarketplaceWebServi
     /**
      * Check to see if Id is set.
      *
-     * @return true if Id is set.
+     * @return bool True if Id is set.
      */
     public function isSetId()
     {

--- a/src/MarketplaceWebServiceProducts/Model/IdentifierType.php
+++ b/src/MarketplaceWebServiceProducts/Model/IdentifierType.php
@@ -71,7 +71,7 @@ class MarketplaceWebServiceProducts_Model_IdentifierType extends MarketplaceWebS
     /**
      * Check to see if MarketplaceASIN is set.
      *
-     * @return true if MarketplaceASIN is set.
+     * @return bool True if MarketplaceASIN is set.
      */
     public function isSetMarketplaceASIN()
     {
@@ -117,7 +117,7 @@ class MarketplaceWebServiceProducts_Model_IdentifierType extends MarketplaceWebS
     /**
      * Check to see if SKUIdentifier is set.
      *
-     * @return true if SKUIdentifier is set.
+     * @return bool True if SKUIdentifier is set.
      */
     public function isSetSKUIdentifier()
     {

--- a/src/MarketplaceWebServiceProducts/Model/ListMatchingProductsRequest.php
+++ b/src/MarketplaceWebServiceProducts/Model/ListMatchingProductsRequest.php
@@ -71,7 +71,7 @@ class MarketplaceWebServiceProducts_Model_ListMatchingProductsRequest extends Ma
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -117,7 +117,7 @@ class MarketplaceWebServiceProducts_Model_ListMatchingProductsRequest extends Ma
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -163,7 +163,7 @@ class MarketplaceWebServiceProducts_Model_ListMatchingProductsRequest extends Ma
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -209,7 +209,7 @@ class MarketplaceWebServiceProducts_Model_ListMatchingProductsRequest extends Ma
     /**
      * Check to see if Query is set.
      *
-     * @return true if Query is set.
+     * @return bool True if Query is set.
      */
     public function isSetQuery()
     {
@@ -255,7 +255,7 @@ class MarketplaceWebServiceProducts_Model_ListMatchingProductsRequest extends Ma
     /**
      * Check to see if QueryContextId is set.
      *
-     * @return true if QueryContextId is set.
+     * @return bool True if QueryContextId is set.
      */
     public function isSetQueryContextId()
     {

--- a/src/MarketplaceWebServiceProducts/Model/ListMatchingProductsResponse.php
+++ b/src/MarketplaceWebServiceProducts/Model/ListMatchingProductsResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceProducts_Model_ListMatchingProductsResponse extends M
     /**
      * Check to see if ListMatchingProductsResult is set.
      *
-     * @return true if ListMatchingProductsResult is set.
+     * @return bool True if ListMatchingProductsResult is set.
      */
     public function isSetListMatchingProductsResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceProducts_Model_ListMatchingProductsResponse extends M
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceProducts_Model_ListMatchingProductsResponse extends M
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceProducts/Model/ListMatchingProductsResult.php
+++ b/src/MarketplaceWebServiceProducts/Model/ListMatchingProductsResult.php
@@ -63,7 +63,7 @@ class MarketplaceWebServiceProducts_Model_ListMatchingProductsResult extends Mar
     /**
      * Check to see if Products is set.
      *
-     * @return true if Products is set.
+     * @return bool True if Products is set.
      */
     public function isSetProducts()
     {

--- a/src/MarketplaceWebServiceProducts/Model/LowestOfferListingList.php
+++ b/src/MarketplaceWebServiceProducts/Model/LowestOfferListingList.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceProducts_Model_LowestOfferListingList extends Marketp
     /**
      * Check to see if LowestOfferListing is set.
      *
-     * @return true if LowestOfferListing is set.
+     * @return bool True if LowestOfferListing is set.
      */
     public function isSetLowestOfferListing()
     {

--- a/src/MarketplaceWebServiceProducts/Model/LowestOfferListingType.php
+++ b/src/MarketplaceWebServiceProducts/Model/LowestOfferListingType.php
@@ -74,7 +74,7 @@ class MarketplaceWebServiceProducts_Model_LowestOfferListingType extends Marketp
     /**
      * Check to see if Qualifiers is set.
      *
-     * @return true if Qualifiers is set.
+     * @return bool True if Qualifiers is set.
      */
     public function isSetQualifiers()
     {
@@ -120,7 +120,7 @@ class MarketplaceWebServiceProducts_Model_LowestOfferListingType extends Marketp
     /**
      * Check to see if NumberOfOfferListingsConsidered is set.
      *
-     * @return true if NumberOfOfferListingsConsidered is set.
+     * @return bool True if NumberOfOfferListingsConsidered is set.
      */
     public function isSetNumberOfOfferListingsConsidered()
     {
@@ -166,7 +166,7 @@ class MarketplaceWebServiceProducts_Model_LowestOfferListingType extends Marketp
     /**
      * Check to see if SellerFeedbackCount is set.
      *
-     * @return true if SellerFeedbackCount is set.
+     * @return bool True if SellerFeedbackCount is set.
      */
     public function isSetSellerFeedbackCount()
     {
@@ -212,7 +212,7 @@ class MarketplaceWebServiceProducts_Model_LowestOfferListingType extends Marketp
     /**
      * Check to see if Price is set.
      *
-     * @return true if Price is set.
+     * @return bool True if Price is set.
      */
     public function isSetPrice()
     {
@@ -258,7 +258,7 @@ class MarketplaceWebServiceProducts_Model_LowestOfferListingType extends Marketp
     /**
      * Check to see if MultipleOffersAtLowestPrice is set.
      *
-     * @return true if MultipleOffersAtLowestPrice is set.
+     * @return bool True if MultipleOffersAtLowestPrice is set.
      */
     public function isSetMultipleOffersAtLowestPrice()
     {

--- a/src/MarketplaceWebServiceProducts/Model/Message.php
+++ b/src/MarketplaceWebServiceProducts/Model/Message.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceProducts_Model_Message extends MarketplaceWebServiceP
     /**
      * Check to see if Locale is set.
      *
-     * @return true if Locale is set.
+     * @return bool True if Locale is set.
      */
     public function isSetLocale()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceProducts_Model_Message extends MarketplaceWebServiceP
     /**
      * Check to see if Text is set.
      *
-     * @return true if Text is set.
+     * @return bool True if Text is set.
      */
     public function isSetText()
     {

--- a/src/MarketplaceWebServiceProducts/Model/MessageList.php
+++ b/src/MarketplaceWebServiceProducts/Model/MessageList.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceProducts_Model_MessageList extends MarketplaceWebServ
     /**
      * Check to see if Message is set.
      *
-     * @return true if Message is set.
+     * @return bool True if Message is set.
      */
     public function isSetMessage()
     {

--- a/src/MarketplaceWebServiceProducts/Model/MoneyType.php
+++ b/src/MarketplaceWebServiceProducts/Model/MoneyType.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceProducts_Model_MoneyType extends MarketplaceWebServic
     /**
      * Check to see if CurrencyCode is set.
      *
-     * @return true if CurrencyCode is set.
+     * @return bool True if CurrencyCode is set.
      */
     public function isSetCurrencyCode()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceProducts_Model_MoneyType extends MarketplaceWebServic
     /**
      * Check to see if Amount is set.
      *
-     * @return true if Amount is set.
+     * @return bool True if Amount is set.
      */
     public function isSetAmount()
     {

--- a/src/MarketplaceWebServiceProducts/Model/NumberOfOfferListingsList.php
+++ b/src/MarketplaceWebServiceProducts/Model/NumberOfOfferListingsList.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceProducts_Model_NumberOfOfferListingsList extends Mark
     /**
      * Check to see if OfferListingCount is set.
      *
-     * @return true if OfferListingCount is set.
+     * @return bool True if OfferListingCount is set.
      */
     public function isSetOfferListingCount()
     {

--- a/src/MarketplaceWebServiceProducts/Model/OfferListingCountType.php
+++ b/src/MarketplaceWebServiceProducts/Model/OfferListingCountType.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceProducts_Model_OfferListingCountType extends Marketpl
     /**
      * Check to see if Value is set.
      *
-     * @return true if Value is set.
+     * @return bool True if Value is set.
      */
     public function isSetValue()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceProducts_Model_OfferListingCountType extends Marketpl
     /**
      * Check to see if condition is set.
      *
-     * @return true if condition is set.
+     * @return bool True if condition is set.
      */
     public function isSetcondition()
     {

--- a/src/MarketplaceWebServiceProducts/Model/OfferType.php
+++ b/src/MarketplaceWebServiceProducts/Model/OfferType.php
@@ -81,7 +81,7 @@ class MarketplaceWebServiceProducts_Model_OfferType extends MarketplaceWebServic
     /**
      * Check to see if BuyingPrice is set.
      *
-     * @return true if BuyingPrice is set.
+     * @return bool True if BuyingPrice is set.
      */
     public function isSetBuyingPrice()
     {
@@ -127,7 +127,7 @@ class MarketplaceWebServiceProducts_Model_OfferType extends MarketplaceWebServic
     /**
      * Check to see if RegularPrice is set.
      *
-     * @return true if RegularPrice is set.
+     * @return bool True if RegularPrice is set.
      */
     public function isSetRegularPrice()
     {
@@ -173,7 +173,7 @@ class MarketplaceWebServiceProducts_Model_OfferType extends MarketplaceWebServic
     /**
      * Check to see if FulfillmentChannel is set.
      *
-     * @return true if FulfillmentChannel is set.
+     * @return bool True if FulfillmentChannel is set.
      */
     public function isSetFulfillmentChannel()
     {
@@ -219,7 +219,7 @@ class MarketplaceWebServiceProducts_Model_OfferType extends MarketplaceWebServic
     /**
      * Check to see if ItemCondition is set.
      *
-     * @return true if ItemCondition is set.
+     * @return bool True if ItemCondition is set.
      */
     public function isSetItemCondition()
     {
@@ -265,7 +265,7 @@ class MarketplaceWebServiceProducts_Model_OfferType extends MarketplaceWebServic
     /**
      * Check to see if ItemSubCondition is set.
      *
-     * @return true if ItemSubCondition is set.
+     * @return bool True if ItemSubCondition is set.
      */
     public function isSetItemSubCondition()
     {
@@ -311,7 +311,7 @@ class MarketplaceWebServiceProducts_Model_OfferType extends MarketplaceWebServic
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -357,7 +357,7 @@ class MarketplaceWebServiceProducts_Model_OfferType extends MarketplaceWebServic
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {

--- a/src/MarketplaceWebServiceProducts/Model/OffersList.php
+++ b/src/MarketplaceWebServiceProducts/Model/OffersList.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceProducts_Model_OffersList extends MarketplaceWebServi
     /**
      * Check to see if Offer is set.
      *
-     * @return true if Offer is set.
+     * @return bool True if Offer is set.
      */
     public function isSetOffer()
     {

--- a/src/MarketplaceWebServiceProducts/Model/PriceType.php
+++ b/src/MarketplaceWebServiceProducts/Model/PriceType.php
@@ -73,7 +73,7 @@ class MarketplaceWebServiceProducts_Model_PriceType extends MarketplaceWebServic
     /**
      * Check to see if LandedPrice is set.
      *
-     * @return true if LandedPrice is set.
+     * @return bool True if LandedPrice is set.
      */
     public function isSetLandedPrice()
     {
@@ -119,7 +119,7 @@ class MarketplaceWebServiceProducts_Model_PriceType extends MarketplaceWebServic
     /**
      * Check to see if ListingPrice is set.
      *
-     * @return true if ListingPrice is set.
+     * @return bool True if ListingPrice is set.
      */
     public function isSetListingPrice()
     {
@@ -165,7 +165,7 @@ class MarketplaceWebServiceProducts_Model_PriceType extends MarketplaceWebServic
     /**
      * Check to see if Shipping is set.
      *
-     * @return true if Shipping is set.
+     * @return bool True if Shipping is set.
      */
     public function isSetShipping()
     {

--- a/src/MarketplaceWebServiceProducts/Model/Product.php
+++ b/src/MarketplaceWebServiceProducts/Model/Product.php
@@ -93,7 +93,7 @@ class MarketplaceWebServiceProducts_Model_Product extends MarketplaceWebServiceP
     /**
      * Check to see if Identifiers is set.
      *
-     * @return true if Identifiers is set.
+     * @return bool True if Identifiers is set.
      */
     public function isSetIdentifiers()
     {
@@ -139,7 +139,7 @@ class MarketplaceWebServiceProducts_Model_Product extends MarketplaceWebServiceP
     /**
      * Check to see if AttributeSets is set.
      *
-     * @return true if AttributeSets is set.
+     * @return bool True if AttributeSets is set.
      */
     public function isSetAttributeSets()
     {
@@ -185,7 +185,7 @@ class MarketplaceWebServiceProducts_Model_Product extends MarketplaceWebServiceP
     /**
      * Check to see if Relationships is set.
      *
-     * @return true if Relationships is set.
+     * @return bool True if Relationships is set.
      */
     public function isSetRelationships()
     {
@@ -231,7 +231,7 @@ class MarketplaceWebServiceProducts_Model_Product extends MarketplaceWebServiceP
     /**
      * Check to see if CompetitivePricing is set.
      *
-     * @return true if CompetitivePricing is set.
+     * @return bool True if CompetitivePricing is set.
      */
     public function isSetCompetitivePricing()
     {
@@ -277,7 +277,7 @@ class MarketplaceWebServiceProducts_Model_Product extends MarketplaceWebServiceP
     /**
      * Check to see if SalesRankings is set.
      *
-     * @return true if SalesRankings is set.
+     * @return bool True if SalesRankings is set.
      */
     public function isSetSalesRankings()
     {
@@ -323,7 +323,7 @@ class MarketplaceWebServiceProducts_Model_Product extends MarketplaceWebServiceP
     /**
      * Check to see if LowestOfferListings is set.
      *
-     * @return true if LowestOfferListings is set.
+     * @return bool True if LowestOfferListings is set.
      */
     public function isSetLowestOfferListings()
     {
@@ -369,7 +369,7 @@ class MarketplaceWebServiceProducts_Model_Product extends MarketplaceWebServiceP
     /**
      * Check to see if Offers is set.
      *
-     * @return true if Offers is set.
+     * @return bool True if Offers is set.
      */
     public function isSetOffers()
     {

--- a/src/MarketplaceWebServiceProducts/Model/ProductList.php
+++ b/src/MarketplaceWebServiceProducts/Model/ProductList.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceProducts_Model_ProductList extends MarketplaceWebServ
     /**
      * Check to see if Product is set.
      *
-     * @return true if Product is set.
+     * @return bool True if Product is set.
      */
     public function isSetProduct()
     {

--- a/src/MarketplaceWebServiceProducts/Model/QualifiersType.php
+++ b/src/MarketplaceWebServiceProducts/Model/QualifiersType.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceProducts_Model_QualifiersType extends MarketplaceWebS
     /**
      * Check to see if ItemCondition is set.
      *
-     * @return true if ItemCondition is set.
+     * @return bool True if ItemCondition is set.
      */
     public function isSetItemCondition()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceProducts_Model_QualifiersType extends MarketplaceWebS
     /**
      * Check to see if ItemSubcondition is set.
      *
-     * @return true if ItemSubcondition is set.
+     * @return bool True if ItemSubcondition is set.
      */
     public function isSetItemSubcondition()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceProducts_Model_QualifiersType extends MarketplaceWebS
     /**
      * Check to see if FulfillmentChannel is set.
      *
-     * @return true if FulfillmentChannel is set.
+     * @return bool True if FulfillmentChannel is set.
      */
     public function isSetFulfillmentChannel()
     {
@@ -214,7 +214,7 @@ class MarketplaceWebServiceProducts_Model_QualifiersType extends MarketplaceWebS
     /**
      * Check to see if ShipsDomestically is set.
      *
-     * @return true if ShipsDomestically is set.
+     * @return bool True if ShipsDomestically is set.
      */
     public function isSetShipsDomestically()
     {
@@ -260,7 +260,7 @@ class MarketplaceWebServiceProducts_Model_QualifiersType extends MarketplaceWebS
     /**
      * Check to see if ShippingTime is set.
      *
-     * @return true if ShippingTime is set.
+     * @return bool True if ShippingTime is set.
      */
     public function isSetShippingTime()
     {
@@ -306,7 +306,7 @@ class MarketplaceWebServiceProducts_Model_QualifiersType extends MarketplaceWebS
     /**
      * Check to see if SellerPositiveFeedbackRating is set.
      *
-     * @return true if SellerPositiveFeedbackRating is set.
+     * @return bool True if SellerPositiveFeedbackRating is set.
      */
     public function isSetSellerPositiveFeedbackRating()
     {

--- a/src/MarketplaceWebServiceProducts/Model/RelationshipList.php
+++ b/src/MarketplaceWebServiceProducts/Model/RelationshipList.php
@@ -77,7 +77,7 @@ class MarketplaceWebServiceProducts_Model_RelationshipList extends MarketplaceWe
     /**
      * Check to see if Any is set.
      *
-     * @return true if Any is set.
+     * @return bool True if Any is set.
      */
     public function isSetAny()
     {

--- a/src/MarketplaceWebServiceProducts/Model/ResponseMetadata.php
+++ b/src/MarketplaceWebServiceProducts/Model/ResponseMetadata.php
@@ -63,7 +63,7 @@ class MarketplaceWebServiceProducts_Model_ResponseMetadata extends MarketplaceWe
     /**
      * Check to see if RequestId is set.
      *
-     * @return true if RequestId is set.
+     * @return bool True if RequestId is set.
      */
     public function isSetRequestId()
     {

--- a/src/MarketplaceWebServiceProducts/Model/SalesRankList.php
+++ b/src/MarketplaceWebServiceProducts/Model/SalesRankList.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceProducts_Model_SalesRankList extends MarketplaceWebSe
     /**
      * Check to see if SalesRank is set.
      *
-     * @return true if SalesRank is set.
+     * @return bool True if SalesRank is set.
      */
     public function isSetSalesRank()
     {

--- a/src/MarketplaceWebServiceProducts/Model/SalesRankType.php
+++ b/src/MarketplaceWebServiceProducts/Model/SalesRankType.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceProducts_Model_SalesRankType extends MarketplaceWebSe
     /**
      * Check to see if ProductCategoryId is set.
      *
-     * @return true if ProductCategoryId is set.
+     * @return bool True if ProductCategoryId is set.
      */
     public function isSetProductCategoryId()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceProducts_Model_SalesRankType extends MarketplaceWebSe
     /**
      * Check to see if Rank is set.
      *
-     * @return true if Rank is set.
+     * @return bool True if Rank is set.
      */
     public function isSetRank()
     {

--- a/src/MarketplaceWebServiceProducts/Model/SellerSKUIdentifier.php
+++ b/src/MarketplaceWebServiceProducts/Model/SellerSKUIdentifier.php
@@ -67,7 +67,7 @@ class MarketplaceWebServiceProducts_Model_SellerSKUIdentifier extends Marketplac
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -113,7 +113,7 @@ class MarketplaceWebServiceProducts_Model_SellerSKUIdentifier extends Marketplac
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -159,7 +159,7 @@ class MarketplaceWebServiceProducts_Model_SellerSKUIdentifier extends Marketplac
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {

--- a/src/MarketplaceWebServiceProducts/Model/SellerSKUListType.php
+++ b/src/MarketplaceWebServiceProducts/Model/SellerSKUListType.php
@@ -77,7 +77,7 @@ class MarketplaceWebServiceProducts_Model_SellerSKUListType extends MarketplaceW
     /**
      * Check to see if SellerSKU is set.
      *
-     * @return true if SellerSKU is set.
+     * @return bool True if SellerSKU is set.
      */
     public function isSetSellerSKU()
     {

--- a/src/MarketplaceWebServiceProducts/Model/ShippingTimeType.php
+++ b/src/MarketplaceWebServiceProducts/Model/ShippingTimeType.php
@@ -63,7 +63,7 @@ class MarketplaceWebServiceProducts_Model_ShippingTimeType extends MarketplaceWe
     /**
      * Check to see if Max is set.
      *
-     * @return true if Max is set.
+     * @return bool True if Max is set.
      */
     public function isSetMax()
     {

--- a/src/MarketplaceWebServiceSellers/Model.php
+++ b/src/MarketplaceWebServiceSellers/Model.php
@@ -404,7 +404,7 @@ abstract class MarketplaceWebServiceSellers_Model
      * Checks  whether passed variable is an associative array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an associative array
+     * @return bool True if passed variable is an associative array
      */
     private function _isAssociativeArray($var)
     {
@@ -415,7 +415,7 @@ abstract class MarketplaceWebServiceSellers_Model
      * Checks  whether passed variable is DOMElement
      *
      * @param mixed $var
-     * @return TRUE if passed variable is DOMElement
+     * @return bool True if passed variable is DOMElement
      */
     private function _isDOMElement($var)
     {
@@ -426,7 +426,7 @@ abstract class MarketplaceWebServiceSellers_Model
      * Checks  whether passed variable is numeric array
      *
      * @param mixed $var
-     * @return TRUE if passed variable is an numeric array
+     * @return bool True if passed variable is an numeric array
      */
     protected function _isNumericArray($var)
     {

--- a/src/MarketplaceWebServiceSellers/Model/GetServiceStatusRequest.php
+++ b/src/MarketplaceWebServiceSellers/Model/GetServiceStatusRequest.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceSellers_Model_GetServiceStatusRequest extends Marketp
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceSellers_Model_GetServiceStatusRequest extends Marketp
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {

--- a/src/MarketplaceWebServiceSellers/Model/GetServiceStatusResponse.php
+++ b/src/MarketplaceWebServiceSellers/Model/GetServiceStatusResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceSellers_Model_GetServiceStatusResponse extends Market
     /**
      * Check to see if GetServiceStatusResult is set.
      *
-     * @return true if GetServiceStatusResult is set.
+     * @return bool True if GetServiceStatusResult is set.
      */
     public function isSetGetServiceStatusResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceSellers_Model_GetServiceStatusResponse extends Market
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceSellers_Model_GetServiceStatusResponse extends Market
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceSellers/Model/GetServiceStatusResult.php
+++ b/src/MarketplaceWebServiceSellers/Model/GetServiceStatusResult.php
@@ -69,7 +69,7 @@ class MarketplaceWebServiceSellers_Model_GetServiceStatusResult extends Marketpl
     /**
      * Check to see if Status is set.
      *
-     * @return true if Status is set.
+     * @return bool True if Status is set.
      */
     public function isSetStatus()
     {
@@ -115,7 +115,7 @@ class MarketplaceWebServiceSellers_Model_GetServiceStatusResult extends Marketpl
     /**
      * Check to see if Timestamp is set.
      *
-     * @return true if Timestamp is set.
+     * @return bool True if Timestamp is set.
      */
     public function isSetTimestamp()
     {
@@ -161,7 +161,7 @@ class MarketplaceWebServiceSellers_Model_GetServiceStatusResult extends Marketpl
     /**
      * Check to see if MessageId is set.
      *
-     * @return true if MessageId is set.
+     * @return bool True if MessageId is set.
      */
     public function isSetMessageId()
     {
@@ -207,7 +207,7 @@ class MarketplaceWebServiceSellers_Model_GetServiceStatusResult extends Marketpl
     /**
      * Check to see if Messages is set.
      *
-     * @return true if Messages is set.
+     * @return bool True if Messages is set.
      */
     public function isSetMessages()
     {

--- a/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsByNextTokenRequest.php
+++ b/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsByNextTokenRequest.php
@@ -67,7 +67,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsByNextToke
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -113,7 +113,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsByNextToke
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {
@@ -159,7 +159,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsByNextToke
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {

--- a/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsByNextTokenResponse.php
+++ b/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsByNextTokenResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsByNextToke
     /**
      * Check to see if ListMarketplaceParticipationsByNextTokenResult is set.
      *
-     * @return true if ListMarketplaceParticipationsByNextTokenResult is set.
+     * @return bool True if ListMarketplaceParticipationsByNextTokenResult is set.
      */
     public function isSetListMarketplaceParticipationsByNextTokenResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsByNextToke
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsByNextToke
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsByNextTokenResult.php
+++ b/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsByNextTokenResult.php
@@ -73,7 +73,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsByNextToke
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -119,7 +119,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsByNextToke
     /**
      * Check to see if ListParticipations is set.
      *
-     * @return true if ListParticipations is set.
+     * @return bool True if ListParticipations is set.
      */
     public function isSetListParticipations()
     {
@@ -165,7 +165,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsByNextToke
     /**
      * Check to see if ListMarketplaces is set.
      *
-     * @return true if ListMarketplaces is set.
+     * @return bool True if ListMarketplaces is set.
      */
     public function isSetListMarketplaces()
     {

--- a/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsRequest.php
+++ b/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsRequest.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsRequest ex
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsRequest ex
     /**
      * Check to see if MWSAuthToken is set.
      *
-     * @return true if MWSAuthToken is set.
+     * @return bool True if MWSAuthToken is set.
      */
     public function isSetMWSAuthToken()
     {

--- a/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsResponse.php
+++ b/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsResponse.php
@@ -76,7 +76,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsResponse e
     /**
      * Check to see if ListMarketplaceParticipationsResult is set.
      *
-     * @return true if ListMarketplaceParticipationsResult is set.
+     * @return bool True if ListMarketplaceParticipationsResult is set.
      */
     public function isSetListMarketplaceParticipationsResult()
     {
@@ -122,7 +122,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsResponse e
     /**
      * Check to see if ResponseMetadata is set.
      *
-     * @return true if ResponseMetadata is set.
+     * @return bool True if ResponseMetadata is set.
      */
     public function isSetResponseMetadata()
     {
@@ -168,7 +168,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsResponse e
     /**
      * Check to see if ResponseHeaderMetadata is set.
      *
-     * @return true if ResponseHeaderMetadata is set.
+     * @return bool True if ResponseHeaderMetadata is set.
      */
     public function isSetResponseHeaderMetadata()
     {

--- a/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsResult.php
+++ b/src/MarketplaceWebServiceSellers/Model/ListMarketplaceParticipationsResult.php
@@ -73,7 +73,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsResult ext
     /**
      * Check to see if NextToken is set.
      *
-     * @return true if NextToken is set.
+     * @return bool True if NextToken is set.
      */
     public function isSetNextToken()
     {
@@ -119,7 +119,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsResult ext
     /**
      * Check to see if ListParticipations is set.
      *
-     * @return true if ListParticipations is set.
+     * @return bool True if ListParticipations is set.
      */
     public function isSetListParticipations()
     {
@@ -165,7 +165,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaceParticipationsResult ext
     /**
      * Check to see if ListMarketplaces is set.
      *
-     * @return true if ListMarketplaces is set.
+     * @return bool True if ListMarketplaces is set.
      */
     public function isSetListMarketplaces()
     {

--- a/src/MarketplaceWebServiceSellers/Model/ListMarketplaces.php
+++ b/src/MarketplaceWebServiceSellers/Model/ListMarketplaces.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceSellers_Model_ListMarketplaces extends MarketplaceWeb
     /**
      * Check to see if Marketplace is set.
      *
-     * @return true if Marketplace is set.
+     * @return bool True if Marketplace is set.
      */
     public function isSetMarketplace()
     {

--- a/src/MarketplaceWebServiceSellers/Model/ListParticipations.php
+++ b/src/MarketplaceWebServiceSellers/Model/ListParticipations.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceSellers_Model_ListParticipations extends MarketplaceW
     /**
      * Check to see if Participation is set.
      *
-     * @return true if Participation is set.
+     * @return bool True if Participation is set.
      */
     public function isSetParticipation()
     {

--- a/src/MarketplaceWebServiceSellers/Model/Marketplace.php
+++ b/src/MarketplaceWebServiceSellers/Model/Marketplace.php
@@ -73,7 +73,7 @@ class MarketplaceWebServiceSellers_Model_Marketplace extends MarketplaceWebServi
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -119,7 +119,7 @@ class MarketplaceWebServiceSellers_Model_Marketplace extends MarketplaceWebServi
     /**
      * Check to see if Name is set.
      *
-     * @return true if Name is set.
+     * @return bool True if Name is set.
      */
     public function isSetName()
     {
@@ -165,7 +165,7 @@ class MarketplaceWebServiceSellers_Model_Marketplace extends MarketplaceWebServi
     /**
      * Check to see if DefaultCountryCode is set.
      *
-     * @return true if DefaultCountryCode is set.
+     * @return bool True if DefaultCountryCode is set.
      */
     public function isSetDefaultCountryCode()
     {
@@ -211,7 +211,7 @@ class MarketplaceWebServiceSellers_Model_Marketplace extends MarketplaceWebServi
     /**
      * Check to see if DefaultCurrencyCode is set.
      *
-     * @return true if DefaultCurrencyCode is set.
+     * @return bool True if DefaultCurrencyCode is set.
      */
     public function isSetDefaultCurrencyCode()
     {
@@ -257,7 +257,7 @@ class MarketplaceWebServiceSellers_Model_Marketplace extends MarketplaceWebServi
     /**
      * Check to see if DefaultLanguageCode is set.
      *
-     * @return true if DefaultLanguageCode is set.
+     * @return bool True if DefaultLanguageCode is set.
      */
     public function isSetDefaultLanguageCode()
     {
@@ -303,7 +303,7 @@ class MarketplaceWebServiceSellers_Model_Marketplace extends MarketplaceWebServi
     /**
      * Check to see if DomainName is set.
      *
-     * @return true if DomainName is set.
+     * @return bool True if DomainName is set.
      */
     public function isSetDomainName()
     {

--- a/src/MarketplaceWebServiceSellers/Model/Message.php
+++ b/src/MarketplaceWebServiceSellers/Model/Message.php
@@ -65,7 +65,7 @@ class MarketplaceWebServiceSellers_Model_Message extends MarketplaceWebServiceSe
     /**
      * Check to see if Locale is set.
      *
-     * @return true if Locale is set.
+     * @return bool True if Locale is set.
      */
     public function isSetLocale()
     {
@@ -111,7 +111,7 @@ class MarketplaceWebServiceSellers_Model_Message extends MarketplaceWebServiceSe
     /**
      * Check to see if Text is set.
      *
-     * @return true if Text is set.
+     * @return bool True if Text is set.
      */
     public function isSetText()
     {

--- a/src/MarketplaceWebServiceSellers/Model/MessageList.php
+++ b/src/MarketplaceWebServiceSellers/Model/MessageList.php
@@ -80,7 +80,7 @@ class MarketplaceWebServiceSellers_Model_MessageList extends MarketplaceWebServi
     /**
      * Check to see if Message is set.
      *
-     * @return true if Message is set.
+     * @return bool True if Message is set.
      */
     public function isSetMessage()
     {

--- a/src/MarketplaceWebServiceSellers/Model/Participation.php
+++ b/src/MarketplaceWebServiceSellers/Model/Participation.php
@@ -67,7 +67,7 @@ class MarketplaceWebServiceSellers_Model_Participation extends MarketplaceWebSer
     /**
      * Check to see if MarketplaceId is set.
      *
-     * @return true if MarketplaceId is set.
+     * @return bool True if MarketplaceId is set.
      */
     public function isSetMarketplaceId()
     {
@@ -113,7 +113,7 @@ class MarketplaceWebServiceSellers_Model_Participation extends MarketplaceWebSer
     /**
      * Check to see if SellerId is set.
      *
-     * @return true if SellerId is set.
+     * @return bool True if SellerId is set.
      */
     public function isSetSellerId()
     {
@@ -159,7 +159,7 @@ class MarketplaceWebServiceSellers_Model_Participation extends MarketplaceWebSer
     /**
      * Check to see if HasSellerSuspendedListings is set.
      *
-     * @return true if HasSellerSuspendedListings is set.
+     * @return bool True if HasSellerSuspendedListings is set.
      */
     public function isSetHasSellerSuspendedListings()
     {

--- a/src/MarketplaceWebServiceSellers/Model/ResponseMetadata.php
+++ b/src/MarketplaceWebServiceSellers/Model/ResponseMetadata.php
@@ -63,7 +63,7 @@ class MarketplaceWebServiceSellers_Model_ResponseMetadata extends MarketplaceWeb
     /**
      * Check to see if RequestId is set.
      *
-     * @return true if RequestId is set.
+     * @return bool True if RequestId is set.
      */
     public function isSetRequestId()
     {


### PR DESCRIPTION
Corrects the return type hinting for booleans, such that we now hint as `bool`, instead of `true`. Performed with a find & replace across the repository.

This enables higher levels of `phpstan` checking (on dependent code), removing errors such as "Negated boolean expression is always false".